### PR TITLE
fix: reject control-less HID devices

### DIFF
--- a/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
+++ b/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		0442B0041A2F4E6C00442004 /* HardcoreModePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0442B0051A2F4E6C00442005 /* HardcoreModePolicyTests.swift */; };
 		05F2F90824EA029900BFAF18 /* Controller-Database.plist in Resources */ = {isa = PBXBuildFile; fileRef = 05F2F90724EA029900BFAF18 /* Controller-Database.plist */; };
 		05FC85B1295E49FE003DED0C /* NSDataCategoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */; };
+		A17E9F012F1A000100000001 /* OEDeviceManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A17E9F022F1A000100000002 /* OEDeviceManagerTests.m */; };
 		05FC85B2295E49FE003DED0C /* OpenEmuSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6772A8C1710CD7E00ED580A /* OpenEmuSystem.framework */; };
 		05FF41B822B08C5F00BB7283 /* OELogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 05FF41B622B08C5F00BB7283 /* OELogging.m */; };
 		05FF41B922B08C5F00BB7283 /* OELogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 05FF41B722B08C5F00BB7283 /* OELogging.h */; };
@@ -172,6 +173,7 @@
 		05F2F90724EA029900BFAF18 /* Controller-Database.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Controller-Database.plist"; sourceTree = "<group>"; };
 		05FC85AE295E49FE003DED0C /* OpenEmuSystemTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenEmuSystemTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSDataCategoryTests.m; sourceTree = "<group>"; };
+		A17E9F022F1A000100000002 /* OEDeviceManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OEDeviceManagerTests.m; sourceTree = "<group>"; };
 		05FF41B622B08C5F00BB7283 /* OELogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OELogging.m; sourceTree = "<group>"; };
 		05FF41B722B08C5F00BB7283 /* OELogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OELogging.h; sourceTree = "<group>"; };
 		27FC95161A92F12700CF1DC6 /* OEDiffQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEDiffQueue.h; sourceTree = "<group>"; };
@@ -317,6 +319,7 @@
 			isa = PBXGroup;
 			children = (
 				05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */,
+				A17E9F022F1A000100000002 /* OEDeviceManagerTests.m */,
 			);
 			path = OpenEmuSystemTests;
 			sourceTree = "<group>";
@@ -776,6 +779,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				05FC85B1295E49FE003DED0C /* NSDataCategoryTests.m in Sources */,
+				A17E9F012F1A000100000001 /* OEDeviceManagerTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager.m
+++ b/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager.m
@@ -481,6 +481,13 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
 
 - (void)OE_addDeviceHandler:(__kindof OEDeviceHandler *)handler
 {
+    if(![handler isKindOfClass:[OEMultiHIDDeviceHandler class]] &&
+       ![handler isKeyboardDevice] &&
+       [[handler controllerDescription] numberOfControls] == 0) {
+        [handler disconnect];
+        return;
+    }
+
     dispatch_barrier_async(_uniqueIdentifiersToDeviceHandlersQueue, ^{
         OEDeviceHandlerPlaceholder *placeholder = self->_uniqueIdentifiersToDeviceHandlers[handler.uniqueIdentifier];
         self->_uniqueIdentifiersToDeviceHandlers[handler.uniqueIdentifier] = handler;
@@ -509,7 +516,6 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
         [_keyboardHandlers addObject:handler];
         [self didChangeValueForKey:@"keyboardDeviceHandlers"];
     } else {
-        NSAssert([[handler controllerDescription] numberOfControls] > 0, @"Handler %@ does not have any controls.", handler);
         [handler setDeviceIdentifier:++_lastAttributedDeviceIdentifier];
         [self willChangeValueForKey:@"controllerDeviceHandlers"];
         [_deviceHandlers addObject:handler];

--- a/OpenEmu-SDK/OpenEmuSystemTests/OEDeviceManagerTests.m
+++ b/OpenEmu-SDK/OpenEmuSystemTests/OEDeviceManagerTests.m
@@ -1,0 +1,92 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <XCTest/XCTest.h>
+#import <OpenEmuSystem/OpenEmuSystem.h>
+
+@interface OEDeviceManager (Testing)
+- (void)OE_addDeviceHandler:(OEDeviceHandler *)handler;
+@end
+
+@interface OETestDeviceManager : OEDeviceManager
+@end
+
+@implementation OETestDeviceManager
+
+- (void)OE_setUpCallbacks
+{
+}
+
+@end
+
+@interface OEZeroControlDeviceHandler : OEDeviceHandler
+@property(nonatomic) BOOL disconnected;
+@end
+
+@implementation OEZeroControlDeviceHandler {
+    OEControllerDescription *_testControllerDescription;
+}
+
+- (instancetype)initWithDeviceDescription:(OEDeviceDescription *)deviceDescription
+{
+    if((self = [super initWithDeviceDescription:deviceDescription]))
+        _testControllerDescription = [[OEControllerDescription alloc] init];
+
+    return self;
+}
+
+- (OEControllerDescription *)controllerDescription
+{
+    return _testControllerDescription;
+}
+
+- (NSString *)uniqueIdentifier
+{
+    return @"zero-control-test-device";
+}
+
+- (void)disconnect
+{
+    self.disconnected = YES;
+}
+
+@end
+
+@interface OEDeviceManagerTests : XCTestCase
+@end
+
+@implementation OEDeviceManagerTests
+
+- (void)testZeroControlControllerIsDisconnectedAndNotRegistered
+{
+    OETestDeviceManager *manager = [[OETestDeviceManager alloc] init];
+    OEZeroControlDeviceHandler *handler = [[OEZeroControlDeviceHandler alloc] initWithDeviceDescription:nil];
+
+    XCTAssertNoThrow([manager OE_addDeviceHandler:handler]);
+    XCTAssertTrue(handler.disconnected);
+    XCTAssertFalse([manager.controllerDeviceHandlers containsObject:handler]);
+    XCTAssertNotEqual([manager deviceHandlerForUniqueIdentifier:handler.uniqueIdentifier], handler);
+}
+
+@end


### PR DESCRIPTION
## What does this PR do?

Prevents OpenEmu from aborting when macOS exposes a non-keyboard HID interface with zero controls. The handler is disconnected and rejected before it can consume an identifier or enter the controller collections; a regression test covers disconnect, controller-collection exclusion, and stale-identifier-map exclusion.

## What did you test?

- Targeted OEDeviceManagerTests: 0 failures on arm64.
- Fresh ./Scripts/verify.sh --worktree --launch: build, static analysis, plist validation, code-signature verification, five-second liveness, and crash-report checks passed.
- Live Xbox Elite Series 2 wired callback: patched OpenEmu remained alive and created no new crash report.

## Which cores or systems are affected?

General OpenEmu HID controller discovery. No emulation core is changed.

## Did you use AI tools?

Yes. Codex helped trace the crash, draft the focused guard and regression test, and run verification. The resulting diff was independently code-reviewed and exercised against the attached controller.

## Linked issues

Fixes #640

---

## How to test locally

```bash
# 1. Check out this PR
gh pr checkout 641 --repo nickybmon/OpenEmu-Silicon

# 2. Build
xcodebuild \
  -workspace OpenEmu-metal.xcworkspace \
  -scheme OpenEmu \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build 2>&1 | tail -20

# 3. Launch
open ~/Library/Developer/Xcode/DerivedData/OpenEmu-metal-*/Build/Products/Debug/OpenEmu.app
```

With OpenEmu closed, connect an Xbox Elite Wireless Controller Series 2 using a USB data cable, unlock the Mac, approve the accessory if prompted, and launch OpenEmu. The app should remain open instead of aborting during HID discovery.

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh`
- [x] Tested on Apple Silicon (M1 Max)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files include the BSD 2-Clause license header
