### PR TITLE
Fix Xbox Elite Series 2 Bluetooth input

### DIFF
--- a/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
+++ b/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
@@ -30,6 +30,10 @@
 		0442B0041A2F4E6C00442004 /* HardcoreModePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0442B0051A2F4E6C00442005 /* HardcoreModePolicyTests.swift */; };
 		05F2F90824EA029900BFAF18 /* Controller-Database.plist in Resources */ = {isa = PBXBuildFile; fileRef = 05F2F90724EA029900BFAF18 /* Controller-Database.plist */; };
 		05FC85B1295E49FE003DED0C /* NSDataCategoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */; };
+		A17EB1012F2B000100000001 /* OEHIDDeviceClassificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A17EB1022F2B000100000002 /* OEHIDDeviceClassificationTests.m */; };
+		A17EB1052F2B000100000005 /* OEGameControllerHIDDeviceHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A17EB1062F2B000100000006 /* OEGameControllerHIDDeviceHandlerTests.m */; };
+		A17EB1082F2B000100000008 /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17EB1072F2B000100000007 /* GameController.framework */; };
+		A17EB1092F2B000100000009 /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17EB1072F2B000100000007 /* GameController.framework */; };
 		05FC85B2295E49FE003DED0C /* OpenEmuSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6772A8C1710CD7E00ED580A /* OpenEmuSystem.framework */; };
 		05FF41B822B08C5F00BB7283 /* OELogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 05FF41B622B08C5F00BB7283 /* OELogging.m */; };
 		05FF41B922B08C5F00BB7283 /* OELogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 05FF41B722B08C5F00BB7283 /* OELogging.h */; };
@@ -89,7 +93,9 @@
 		C6772BB81710E28900ED580A /* OEDeviceHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = C6772BA31710E28900ED580A /* OEDeviceHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C6772BB91710E28900ED580A /* OEDeviceHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C6772BA41710E28900ED580A /* OEDeviceHandler.m */; };
 		C6772BBA1710E28900ED580A /* OEHIDDeviceHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = C6772BA51710E28900ED580A /* OEHIDDeviceHandler.h */; };
+		A17EB1032F2B000100000003 /* OEHIDDeviceHandler_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = A17EB1042F2B000100000004 /* OEHIDDeviceHandler_Internal.h */; };
 		C6772BBB1710E28900ED580A /* OEHIDDeviceHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C6772BA61710E28900ED580A /* OEHIDDeviceHandler.m */; };
+		A17EB10C2F2B00010000000C /* OEGameControllerHIDDeviceHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = A17EB10B2F2B00010000000B /* OEGameControllerHIDDeviceHandler.m */; };
 		C6772BBC1710E28900ED580A /* OEMultiHIDDeviceHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = C6772BA71710E28900ED580A /* OEMultiHIDDeviceHandler.h */; };
 		C6772BBD1710E28900ED580A /* OEMultiHIDDeviceHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C6772BA81710E28900ED580A /* OEMultiHIDDeviceHandler.m */; };
 		C6772BBE1710E28900ED580A /* OEWiimoteHIDDeviceHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = C6772BA91710E28900ED580A /* OEWiimoteHIDDeviceHandler.h */; };
@@ -172,6 +178,9 @@
 		05F2F90724EA029900BFAF18 /* Controller-Database.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Controller-Database.plist"; sourceTree = "<group>"; };
 		05FC85AE295E49FE003DED0C /* OpenEmuSystemTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenEmuSystemTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSDataCategoryTests.m; sourceTree = "<group>"; };
+		A17EB1022F2B000100000002 /* OEHIDDeviceClassificationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OEHIDDeviceClassificationTests.m; sourceTree = "<group>"; };
+		A17EB1062F2B000100000006 /* OEGameControllerHIDDeviceHandlerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OEGameControllerHIDDeviceHandlerTests.m; sourceTree = "<group>"; };
+		A17EB1072F2B000100000007 /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = System/Library/Frameworks/GameController.framework; sourceTree = SDKROOT; };
 		05FF41B622B08C5F00BB7283 /* OELogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OELogging.m; sourceTree = "<group>"; };
 		05FF41B722B08C5F00BB7283 /* OELogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OELogging.h; sourceTree = "<group>"; };
 		27FC95161A92F12700CF1DC6 /* OEDiffQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEDiffQueue.h; sourceTree = "<group>"; };
@@ -236,7 +245,10 @@
 		C6772BA31710E28900ED580A /* OEDeviceHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEDeviceHandler.h; sourceTree = "<group>"; };
 		C6772BA41710E28900ED580A /* OEDeviceHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEDeviceHandler.m; sourceTree = "<group>"; };
 		C6772BA51710E28900ED580A /* OEHIDDeviceHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEHIDDeviceHandler.h; sourceTree = "<group>"; };
+		A17EB1042F2B000100000004 /* OEHIDDeviceHandler_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEHIDDeviceHandler_Internal.h; sourceTree = "<group>"; };
 		C6772BA61710E28900ED580A /* OEHIDDeviceHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEHIDDeviceHandler.m; sourceTree = "<group>"; };
+		A17EB10A2F2B00010000000A /* OEGameControllerHIDDeviceHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEGameControllerHIDDeviceHandler.h; sourceTree = "<group>"; };
+		A17EB10B2F2B00010000000B /* OEGameControllerHIDDeviceHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEGameControllerHIDDeviceHandler.m; sourceTree = "<group>"; };
 		C6772BA71710E28900ED580A /* OEMultiHIDDeviceHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEMultiHIDDeviceHandler.h; sourceTree = "<group>"; };
 		C6772BA81710E28900ED580A /* OEMultiHIDDeviceHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEMultiHIDDeviceHandler.m; sourceTree = "<group>"; };
 		C6772BA91710E28900ED580A /* OEWiimoteHIDDeviceHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEWiimoteHIDDeviceHandler.h; sourceTree = "<group>"; };
@@ -282,6 +294,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				05FC85B2295E49FE003DED0C /* OpenEmuSystem.framework in Frameworks */,
+				A17EB1092F2B000100000009 /* GameController.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -297,6 +310,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C6772BE11710E72A00ED580A /* OpenEmuBase.framework in Frameworks */,
+				A17EB1082F2B000100000008 /* GameController.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -317,6 +331,8 @@
 			isa = PBXGroup;
 			children = (
 				05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */,
+				A17EB1022F2B000100000002 /* OEHIDDeviceClassificationTests.m */,
+				A17EB1062F2B000100000006 /* OEGameControllerHIDDeviceHandlerTests.m */,
 			);
 			path = OpenEmuSystemTests;
 			sourceTree = "<group>";
@@ -338,6 +354,7 @@
 				C6772A8E1710CD7E00ED580A /* OpenEmuSystem */,
 				0109BBA3209F25EB002419C1 /* OpenEmuBaseTests */,
 				05FC85AF295E49FE003DED0C /* OpenEmuSystemTests */,
+				A17EB1072F2B000100000007 /* GameController.framework */,
 				C6772A271710A4BA00ED580A /* Products */,
 			);
 			indentWidth = 4;
@@ -492,7 +509,10 @@
 				C6772BAB1710E28900ED580A /* OEHIDDeviceParser.h */,
 				C6772BAC1710E28900ED580A /* OEHIDDeviceParser.m */,
 				C6772BA51710E28900ED580A /* OEHIDDeviceHandler.h */,
+				A17EB1042F2B000100000004 /* OEHIDDeviceHandler_Internal.h */,
 				C6772BA61710E28900ED580A /* OEHIDDeviceHandler.m */,
+				A17EB10A2F2B00010000000A /* OEGameControllerHIDDeviceHandler.h */,
+				A17EB10B2F2B00010000000B /* OEGameControllerHIDDeviceHandler.m */,
 				C6772BA71710E28900ED580A /* OEMultiHIDDeviceHandler.h */,
 				C6772BA81710E28900ED580A /* OEMultiHIDDeviceHandler.m */,
 				C6772BA91710E28900ED580A /* OEWiimoteHIDDeviceHandler.h */,
@@ -597,6 +617,7 @@
 				C6772B971710E25300ED580A /* OEBindingsController_Internal.h in Headers */,
 				C6772BD31710E29C00ED580A /* OEControllerDescription_Internal.h in Headers */,
 				C6772BBA1710E28900ED580A /* OEHIDDeviceHandler.h in Headers */,
+				A17EB1032F2B000100000003 /* OEHIDDeviceHandler_Internal.h in Headers */,
 				C6772BC01710E28900ED580A /* OEHIDDeviceParser.h in Headers */,
 				C6772BC61710E28900ED580A /* OEHIDUsageToVK.h in Headers */,
 				C6772BBC1710E28900ED580A /* OEMultiHIDDeviceHandler.h in Headers */,
@@ -776,6 +797,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				05FC85B1295E49FE003DED0C /* NSDataCategoryTests.m in Sources */,
+				A17EB1012F2B000100000001 /* OEHIDDeviceClassificationTests.m in Sources */,
+				A17EB1052F2B000100000005 /* OEGameControllerHIDDeviceHandlerTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -823,6 +846,7 @@
 				C6772BB91710E28900ED580A /* OEDeviceHandler.m in Sources */,
 				01AFC70D2364E327005EEB08 /* DataProtocol+HexString.swift in Sources */,
 				C6772BBB1710E28900ED580A /* OEHIDDeviceHandler.m in Sources */,
+				A17EB10C2F2B00010000000C /* OEGameControllerHIDDeviceHandler.m in Sources */,
 				C6772BBD1710E28900ED580A /* OEMultiHIDDeviceHandler.m in Sources */,
 				C6772BBF1710E28900ED580A /* OEWiimoteHIDDeviceHandler.m in Sources */,
 				C6772BC11710E28900ED580A /* OEHIDDeviceParser.m in Sources */,

--- a/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager.m
+++ b/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager.m
@@ -29,6 +29,7 @@
 #import "OEDeviceHandler.h"
 #import "OEControllerDescription.h"
 #import "OEHIDDeviceHandler.h"
+#import "OEHIDDeviceHandler_Internal.h"
 #import "OEMultiHIDDeviceHandler.h"
 #import "OEWiimoteHIDDeviceHandler.h"
 #import "OEPS3HIDDeviceHandler.h"
@@ -38,6 +39,8 @@
 #import "OEHIDEvent_Internal.h"
 
 #import <objc/runtime.h>
+#import <IOKit/IOKitLib.h>
+#import <GameController/GameController.h>
 
 #import <IOBluetooth/IOBluetooth.h>
 #import <IOBluetooth/objc/IOBluetoothDeviceInquiry.h>
@@ -61,6 +64,31 @@ NSString *const OEDeviceManagerDeviceHandlerUserInfoKey           = @"OEDeviceMa
 @end
 
 static void OEHandle_DeviceMatchingCallback(void *inContext, IOReturn inResult, void *inSender, IOHIDDeviceRef inIOHIDDeviceRef);
+
+static NSNumber * _Nullable OERegistryEntryIDForHIDDevice(IOHIDDeviceRef device)
+{
+    if(device == NULL)
+        return nil;
+
+    io_service_t service = IOHIDDeviceGetService(device);
+    uint64_t registryEntryID = 0;
+    if(service == IO_OBJECT_NULL ||
+       IORegistryEntryGetRegistryEntryID(service, &registryEntryID) != KERN_SUCCESS)
+        return nil;
+
+    return @(registryEntryID);
+}
+
+static NSString * _Nullable OERegistryIdentityForHIDDevice(IOHIDDeviceRef device)
+{
+    if(device == NULL)
+        return nil;
+
+    NSNumber *registryEntryID = OERegistryEntryIDForHIDDevice(device);
+    return registryEntryID != nil
+         ? [NSString stringWithFormat:@"registry:%@", registryEntryID]
+         : [NSString stringWithFormat:@"pointer:%p", (void *)device];
+}
 
 static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePairSyncStyleKey;
 
@@ -122,6 +150,36 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
     });
 
     return sharedHIDManager;
+}
+
+- (BOOL)OE_hasSingleGameControllerSupportedHIDDeviceMatchingDevice:(IOHIDDeviceRef)expectedDevice
+{
+    if(_hidManager == NULL || expectedDevice == NULL)
+        return NO;
+
+    if(@available(macOS 11.0, *)) {
+        CFSetRef devices = IOHIDManagerCopyDevices(_hidManager);
+        if(devices == NULL)
+            return NO;
+
+        NSMutableSet<NSString *> *identities = [NSMutableSet set];
+        for(id object in (__bridge NSSet *)devices) {
+            IOHIDDeviceRef device = (__bridge IOHIDDeviceRef)object;
+            BOOL isGameController = IOHIDDeviceConformsTo(device, kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick) ||
+                                    IOHIDDeviceConformsTo(device, kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad);
+            if(isGameController && [GCController supportsHIDDevice:device]) {
+                NSString *identity = OERegistryIdentityForHIDDevice(device);
+                if(identity != nil)
+                    [identities addObject:identity];
+            }
+        }
+
+        CFRelease(devices);
+        NSString *expectedIdentity = OERegistryIdentityForHIDDevice(expectedDevice);
+        return expectedIdentity != nil && identities.count == 1 && [identities containsObject:expectedIdentity];
+    }
+
+    return NO;
 }
 
 - (instancetype)init
@@ -467,7 +525,7 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
     NSAssert(device != NULL, @"Passing NULL device.");
 
     OEHIDDeviceHandler *handler = nil;
-    if(IOHIDDeviceConformsTo(device, kHIDPage_GenericDesktop, kHIDUsage_GD_Keyboard)) {
+    if(OEHIDDeviceIsKeyboardOnly(device)) {
         if (!istouchbar)
             handler = [[OEHIDDeviceHandler alloc] initWithIOHIDDevice:device deviceDescription:nil];
         else
@@ -519,18 +577,42 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
     [[NSNotificationCenter defaultCenter] postNotificationName:OEDeviceManagerDidAddDeviceHandlerNotification object:self userInfo:@{ OEDeviceManagerDeviceHandlerUserInfoKey : handler }];
 }
 
-- (BOOL)OE_hasDeviceHandlerForDeviceRef:(IOHIDDeviceRef)deviceRef
+- (nullable NSNumber *)OE_registryEntryIDForDeviceHandler:(OEDeviceHandler *)handler
 {
-    __block BOOL didFoundDevice = NO;
+    if(![handler isKindOfClass:[OEHIDDeviceHandler class]])
+        return nil;
+
+    return OERegistryEntryIDForHIDDevice([(OEHIDDeviceHandler *)handler device]);
+}
+
+- (BOOL)OE_hasDeviceHandlerForDeviceRef:(nullable IOHIDDeviceRef)deviceRef
+                        registryEntryID:(nullable NSNumber *)registryEntryID
+{
+    __block BOOL didFindDevice = NO;
     [self OE_enumerateDevicesUsingBlock:^(OEDeviceHandler *handler, BOOL *stop) {
-        if(![handler isKindOfClass:[OEHIDDeviceHandler class]] || [(OEHIDDeviceHandler *)handler device] != deviceRef)
+        BOOL hasSameDeviceRef =
+            deviceRef != NULL &&
+            [handler isKindOfClass:[OEHIDDeviceHandler class]] &&
+            [(OEHIDDeviceHandler *)handler device] == deviceRef;
+        NSNumber *handlerRegistryEntryID = [self OE_registryEntryIDForDeviceHandler:handler];
+        BOOL hasSameRegistryEntryID =
+            registryEntryID != nil &&
+            handlerRegistryEntryID != nil &&
+            [handlerRegistryEntryID isEqualToNumber:registryEntryID];
+        if(!hasSameDeviceRef && !hasSameRegistryEntryID)
             return;
 
-        didFoundDevice = YES;
+        didFindDevice = YES;
         *stop = YES;
     }];
 
-    return didFoundDevice;
+    return didFindDevice;
+}
+
+- (BOOL)OE_hasDeviceHandlerForDeviceRef:(IOHIDDeviceRef)deviceRef
+{
+    return [self OE_hasDeviceHandlerForDeviceRef:deviceRef
+                                registryEntryID:OERegistryEntryIDForHIDDevice(deviceRef)];
 }
 
 - (void)OE_removeDeviceHandler:(__kindof OEDeviceHandler *)handler

--- a/OpenEmu-SDK/OpenEmuSystem/OEGameControllerHIDDeviceHandler.h
+++ b/OpenEmu-SDK/OpenEmuSystem/OEGameControllerHIDDeviceHandler.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import "OEHIDDeviceHandler.h"
+
+@class GCController;
+@class GCControllerElement;
+@class GCExtendedGamepad;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSUInteger, OEGameControllerSyntheticCookie) {
+    OEGameControllerCookieButtonA                = 0x10001,
+    OEGameControllerCookieButtonB                = 0x10002,
+    OEGameControllerCookieButtonX                = 0x10003,
+    OEGameControllerCookieButtonY                = 0x10004,
+    OEGameControllerCookieLeftShoulder           = 0x10005,
+    OEGameControllerCookieRightShoulder          = 0x10006,
+    OEGameControllerCookieButtonOptions          = 0x10007,
+    OEGameControllerCookieButtonMenu             = 0x10008,
+    OEGameControllerCookieLeftThumbstickButton   = 0x10009,
+    OEGameControllerCookieRightThumbstickButton  = 0x1000A,
+    OEGameControllerCookieButtonHome             = 0x1000B,
+    OEGameControllerCookieDPad                   = 0x10100,
+    OEGameControllerCookieLeftThumbstickX        = 0x10200,
+    OEGameControllerCookieLeftThumbstickY        = 0x10201,
+    OEGameControllerCookieRightThumbstickX       = 0x10202,
+    OEGameControllerCookieRightThumbstickY       = 0x10203,
+    OEGameControllerCookieLeftTrigger            = 0x10300,
+    OEGameControllerCookieRightTrigger           = 0x10301,
+};
+
+@interface OEGameControllerHIDDeviceHandler : OEHIDDeviceHandler
+
++ (BOOL)OE_matchesVendorID:(NSUInteger)vendorID
+                 productID:(NSUInteger)productID
+    gameControllerSupported:(BOOL)gameControllerSupported;
+
++ (NSArray<OEHIDEvent *> *)OE_eventsForExtendedGamepad:(GCExtendedGamepad *)gamepad
+                                        changedElement:(GCControllerElement *)element
+                                         deviceHandler:(nullable OEDeviceHandler *)deviceHandler;
+
++ (NSArray<OEHIDEvent *> *)OE_neutralEventsWithDeviceHandler:(nullable OEDeviceHandler *)deviceHandler;
+
++ (nullable GCController *)OE_controllerForUnambiguousCandidates:(NSArray<GCController *> *)candidates
+                                            waitingHandlerCount:(NSUInteger)waitingHandlerCount
+                   hasExclusiveGameControllerSupportedHIDDevice:(BOOL)hasExclusiveGameControllerSupportedHIDDevice;
+
++ (BOOL)OE_shouldDispatchChangedGamepad:(GCExtendedGamepad *)changedGamepad
+                         currentGamepad:(nullable GCExtendedGamepad *)currentGamepad
+                           disconnected:(BOOL)disconnected
+             capturedAttachmentGeneration:(NSUInteger)capturedAttachmentGeneration
+              currentAttachmentGeneration:(NSUInteger)currentAttachmentGeneration;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OpenEmu-SDK/OpenEmuSystem/OEGameControllerHIDDeviceHandler.m
+++ b/OpenEmu-SDK/OpenEmuSystem/OEGameControllerHIDDeviceHandler.m
@@ -1,0 +1,558 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import "OEGameControllerHIDDeviceHandler.h"
+
+#import "OEControlDescription.h"
+#import "OEControllerDescription.h"
+#import "OEHIDEvent_Internal.h"
+#import "OEDeviceManager_Internal.h"
+
+#import <GameController/GameController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static const NSUInteger OEGameControllerEliteVendorID = 0x045E;
+static const NSUInteger OEGameControllerEliteBluetoothProductID = 0x0B05;
+static const NSInteger OEGameControllerTriggerMaximum = 0xFFFF;
+
+static NSMapTable<GCController *, OEGameControllerHIDDeviceHandler *> *OEGameControllerClaims(void)
+{
+    static NSMapTable<GCController *, OEGameControllerHIDDeviceHandler *> *claims = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSPointerFunctionsOptions keyOptions = NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality;
+        NSPointerFunctionsOptions valueOptions = NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality;
+        claims = [NSMapTable mapTableWithKeyOptions:keyOptions valueOptions:valueOptions];
+    });
+
+    return claims;
+}
+
+static NSHashTable<OEGameControllerHIDDeviceHandler *> *OEGameControllerHandlers(void)
+{
+    static NSHashTable<OEGameControllerHIDDeviceHandler *> *handlers = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSPointerFunctionsOptions options = NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality;
+        handlers = [NSHashTable hashTableWithOptions:options];
+    });
+
+    return handlers;
+}
+
+static BOOL OEElementBelongsToDirectionPad(GCControllerElement *element, GCControllerDirectionPad *directionPad)
+{
+    return element == directionPad ||
+           element == directionPad.xAxis ||
+           element == directionPad.yAxis ||
+           element == directionPad.up ||
+           element == directionPad.down ||
+           element == directionPad.left ||
+           element == directionPad.right;
+}
+
+static OEHIDEvent *OEGameControllerButtonEvent(OEDeviceHandler * _Nullable deviceHandler,
+                                                NSTimeInterval timestamp,
+                                                GCControllerButtonInput *button,
+                                                NSUInteger buttonNumber,
+                                                NSUInteger cookie)
+{
+    OEHIDEventState state = button.isPressed ? OEHIDEventStateOn : OEHIDEventStateOff;
+    return [OEHIDEvent buttonEventWithDeviceHandler:deviceHandler
+                                          timestamp:timestamp
+                                       buttonNumber:buttonNumber
+                                              state:state
+                                             cookie:cookie];
+}
+
+static OEHIDEvent *OEGameControllerAxisEvent(OEDeviceHandler * _Nullable deviceHandler,
+                                              NSTimeInterval timestamp,
+                                              GCControllerAxisInput *axisInput,
+                                              OEHIDEventAxis axis,
+                                              NSUInteger cookie)
+{
+    return [OEHIDEvent axisEventWithDeviceHandler:deviceHandler
+                                         timestamp:timestamp
+                                              axis:axis
+                                             value:axisInput.value
+                                            cookie:cookie];
+}
+
+static OEHIDEvent *OEGameControllerTriggerEvent(OEDeviceHandler * _Nullable deviceHandler,
+                                                 NSTimeInterval timestamp,
+                                                 GCControllerButtonInput *trigger,
+                                                 OEHIDEventAxis axis,
+                                                 NSUInteger cookie)
+{
+    NSInteger value = lroundf(trigger.value * OEGameControllerTriggerMaximum);
+    return [OEHIDEvent triggerEventWithDeviceHandler:deviceHandler
+                                            timestamp:timestamp
+                                                 axis:axis
+                                                value:value
+                                              maximum:OEGameControllerTriggerMaximum
+                                               cookie:cookie];
+}
+
+static void OEAddSyntheticControl(OEControllerDescription *description, NSString *name, OEHIDEvent *event)
+{
+    OEControlDescription *control = [description addControlWithIdentifier:nil name:name event:event];
+    if(!description.isGeneric)
+        [control setUpControlValuesUsingRepresentations:nil];
+}
+
+@interface OEGameControllerHIDDeviceHandler ()
+- (void)OE_addSyntheticControls;
+- (void)OE_attachAvailableGameController;
+- (void)OE_scheduleAttachmentEvaluation;
+- (void)OE_tryAttachGameController:(GCController *)controller;
+- (BOOL)OE_isEligibleGameController:(GCController *)controller;
+- (void)OE_detachGameController;
+- (void)OE_dispatchNeutralEvents;
+- (void)OE_controllerDidConnect:(NSNotification *)notification;
+- (void)OE_controllerDidDisconnect:(NSNotification *)notification;
+@end
+
+@implementation OEGameControllerHIDDeviceHandler {
+    GCController *_gameController;
+    GCExtendedGamepad *_extendedGamepad;
+    GCExtendedGamepadValueChangedHandler _gamepadValueChangedHandler;
+    BOOL _disconnected;
+    NSUInteger _attachmentEvaluationGeneration;
+    NSUInteger _attachmentGeneration;
+}
+
++ (BOOL)OE_matchesVendorID:(NSUInteger)vendorID
+                 productID:(NSUInteger)productID
+    gameControllerSupported:(BOOL)gameControllerSupported
+{
+    return gameControllerSupported &&
+           vendorID == OEGameControllerEliteVendorID &&
+           productID == OEGameControllerEliteBluetoothProductID;
+}
+
++ (nullable GCController *)OE_controllerForUnambiguousCandidates:(NSArray<GCController *> *)candidates
+                                            waitingHandlerCount:(NSUInteger)waitingHandlerCount
+                   hasExclusiveGameControllerSupportedHIDDevice:(BOOL)hasExclusiveGameControllerSupportedHIDDevice
+{
+    if(candidates.count != 1 ||
+       waitingHandlerCount != 1 ||
+       !hasExclusiveGameControllerSupportedHIDDevice)
+        return nil;
+
+    return candidates.firstObject;
+}
+
++ (BOOL)OE_shouldDispatchChangedGamepad:(GCExtendedGamepad *)changedGamepad
+                         currentGamepad:(nullable GCExtendedGamepad *)currentGamepad
+                           disconnected:(BOOL)disconnected
+             capturedAttachmentGeneration:(NSUInteger)capturedAttachmentGeneration
+              currentAttachmentGeneration:(NSUInteger)currentAttachmentGeneration
+{
+    return !disconnected &&
+           changedGamepad == currentGamepad &&
+           capturedAttachmentGeneration == currentAttachmentGeneration;
+}
+
++ (BOOL)canHandleDevice:(IOHIDDeviceRef)device
+{
+    if(device == NULL)
+        return NO;
+
+    NSUInteger vendorID = [(__bridge NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey)) unsignedIntegerValue];
+    NSUInteger productID = [(__bridge NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductIDKey)) unsignedIntegerValue];
+
+    if(![self OE_matchesVendorID:vendorID productID:productID gameControllerSupported:YES])
+        return NO;
+
+    if(@available(macOS 11.0, *))
+        return [GCController supportsHIDDevice:device];
+
+    return NO;
+}
+
++ (NSArray<OEHIDEvent *> *)OE_eventsForExtendedGamepad:(GCExtendedGamepad *)gamepad
+                                        changedElement:(GCControllerElement *)element
+                                         deviceHandler:(nullable OEDeviceHandler *)deviceHandler
+{
+    NSMutableArray<OEHIDEvent *> *events = [NSMutableArray arrayWithCapacity:2];
+    NSTimeInterval timestamp = NSProcessInfo.processInfo.systemUptime;
+
+    if(element == gamepad.buttonA)
+        [events addObject:OEGameControllerButtonEvent(deviceHandler, timestamp, gamepad.buttonA, 1, OEGameControllerCookieButtonA)];
+    else if(element == gamepad.buttonB)
+        [events addObject:OEGameControllerButtonEvent(deviceHandler, timestamp, gamepad.buttonB, 2, OEGameControllerCookieButtonB)];
+    else if(element == gamepad.buttonX)
+        [events addObject:OEGameControllerButtonEvent(deviceHandler, timestamp, gamepad.buttonX, 3, OEGameControllerCookieButtonX)];
+    else if(element == gamepad.buttonY)
+        [events addObject:OEGameControllerButtonEvent(deviceHandler, timestamp, gamepad.buttonY, 4, OEGameControllerCookieButtonY)];
+    else if(element == gamepad.leftShoulder)
+        [events addObject:OEGameControllerButtonEvent(deviceHandler, timestamp, gamepad.leftShoulder, 5, OEGameControllerCookieLeftShoulder)];
+    else if(element == gamepad.rightShoulder)
+        [events addObject:OEGameControllerButtonEvent(deviceHandler, timestamp, gamepad.rightShoulder, 6, OEGameControllerCookieRightShoulder)];
+    else if(element == gamepad.leftTrigger)
+        [events addObject:OEGameControllerTriggerEvent(deviceHandler, timestamp, gamepad.leftTrigger, OEHIDEventAxisBrake, OEGameControllerCookieLeftTrigger)];
+    else if(element == gamepad.rightTrigger)
+        [events addObject:OEGameControllerTriggerEvent(deviceHandler, timestamp, gamepad.rightTrigger, OEHIDEventAxisAccelerator, OEGameControllerCookieRightTrigger)];
+
+    if(events.count != 0)
+        return events;
+
+    if(@available(macOS 10.15, *)) {
+        if(element == gamepad.buttonOptions)
+            [events addObject:OEGameControllerButtonEvent(deviceHandler, timestamp, gamepad.buttonOptions, 7, OEGameControllerCookieButtonOptions)];
+        else if(element == gamepad.buttonMenu)
+            [events addObject:OEGameControllerButtonEvent(deviceHandler, timestamp, gamepad.buttonMenu, 8, OEGameControllerCookieButtonMenu)];
+    }
+
+    if(events.count != 0)
+        return events;
+
+    if(element == gamepad.leftThumbstickButton)
+        [events addObject:OEGameControllerButtonEvent(deviceHandler, timestamp, gamepad.leftThumbstickButton, 9, OEGameControllerCookieLeftThumbstickButton)];
+    else if(element == gamepad.rightThumbstickButton)
+        [events addObject:OEGameControllerButtonEvent(deviceHandler, timestamp, gamepad.rightThumbstickButton, 10, OEGameControllerCookieRightThumbstickButton)];
+
+    if(events.count != 0)
+        return events;
+
+    if(@available(macOS 11.0, *)) {
+        if(element == gamepad.buttonHome)
+            [events addObject:OEGameControllerButtonEvent(deviceHandler, timestamp, gamepad.buttonHome, 11, OEGameControllerCookieButtonHome)];
+    }
+
+    if(events.count != 0)
+        return events;
+
+    if(OEElementBelongsToDirectionPad(element, gamepad.dpad)) {
+        OEHIDEventHatDirection direction = OEHIDEventHatDirectionNull;
+        if(gamepad.dpad.up.isPressed)
+            direction |= OEHIDEventHatDirectionNorth;
+        if(gamepad.dpad.right.isPressed)
+            direction |= OEHIDEventHatDirectionEast;
+        if(gamepad.dpad.down.isPressed)
+            direction |= OEHIDEventHatDirectionSouth;
+        if(gamepad.dpad.left.isPressed)
+            direction |= OEHIDEventHatDirectionWest;
+
+        [events addObject:[OEHIDEvent hatSwitchEventWithDeviceHandler:deviceHandler
+                                                            timestamp:timestamp
+                                                                 type:OEHIDEventHatSwitchType8Ways
+                                                            direction:direction
+                                                               cookie:OEGameControllerCookieDPad]];
+        return events;
+    }
+
+    GCControllerDirectionPad *leftThumbstick = gamepad.leftThumbstick;
+    if(element == leftThumbstick || element == leftThumbstick.xAxis || element == leftThumbstick.left || element == leftThumbstick.right)
+        [events addObject:OEGameControllerAxisEvent(deviceHandler, timestamp, leftThumbstick.xAxis, OEHIDEventAxisX, OEGameControllerCookieLeftThumbstickX)];
+    if(element == leftThumbstick || element == leftThumbstick.yAxis || element == leftThumbstick.up || element == leftThumbstick.down)
+        [events addObject:OEGameControllerAxisEvent(deviceHandler, timestamp, leftThumbstick.yAxis, OEHIDEventAxisY, OEGameControllerCookieLeftThumbstickY)];
+
+    if(events.count != 0)
+        return events;
+
+    GCControllerDirectionPad *rightThumbstick = gamepad.rightThumbstick;
+    if(element == rightThumbstick || element == rightThumbstick.xAxis || element == rightThumbstick.left || element == rightThumbstick.right)
+        [events addObject:OEGameControllerAxisEvent(deviceHandler, timestamp, rightThumbstick.xAxis, OEHIDEventAxisRx, OEGameControllerCookieRightThumbstickX)];
+    if(element == rightThumbstick || element == rightThumbstick.yAxis || element == rightThumbstick.up || element == rightThumbstick.down)
+        [events addObject:OEGameControllerAxisEvent(deviceHandler, timestamp, rightThumbstick.yAxis, OEHIDEventAxisRy, OEGameControllerCookieRightThumbstickY)];
+
+    return events;
+}
+
++ (NSArray<OEHIDEvent *> *)OE_neutralEventsWithDeviceHandler:(nullable OEDeviceHandler *)deviceHandler
+{
+    NSTimeInterval timestamp = NSProcessInfo.processInfo.systemUptime;
+    NSArray<NSNumber *> *buttonCookies = @[
+        @(OEGameControllerCookieButtonA),
+        @(OEGameControllerCookieButtonB),
+        @(OEGameControllerCookieButtonX),
+        @(OEGameControllerCookieButtonY),
+        @(OEGameControllerCookieLeftShoulder),
+        @(OEGameControllerCookieRightShoulder),
+        @(OEGameControllerCookieButtonOptions),
+        @(OEGameControllerCookieButtonMenu),
+        @(OEGameControllerCookieLeftThumbstickButton),
+        @(OEGameControllerCookieRightThumbstickButton),
+        @(OEGameControllerCookieButtonHome),
+    ];
+    NSMutableArray<OEHIDEvent *> *events = [NSMutableArray arrayWithCapacity:18];
+    [buttonCookies enumerateObjectsUsingBlock:^(NSNumber *cookie, NSUInteger index, BOOL *stop) {
+        [events addObject:[OEHIDEvent buttonEventWithDeviceHandler:deviceHandler
+                                                        timestamp:timestamp
+                                                     buttonNumber:index + 1
+                                                            state:OEHIDEventStateOff
+                                                           cookie:cookie.unsignedIntegerValue]];
+    }];
+    [events addObject:[OEHIDEvent hatSwitchEventWithDeviceHandler:deviceHandler timestamp:timestamp type:OEHIDEventHatSwitchType8Ways direction:OEHIDEventHatDirectionNull cookie:OEGameControllerCookieDPad]];
+    [events addObject:[OEHIDEvent axisEventWithDeviceHandler:deviceHandler timestamp:timestamp axis:OEHIDEventAxisX value:0.0 cookie:OEGameControllerCookieLeftThumbstickX]];
+    [events addObject:[OEHIDEvent axisEventWithDeviceHandler:deviceHandler timestamp:timestamp axis:OEHIDEventAxisY value:0.0 cookie:OEGameControllerCookieLeftThumbstickY]];
+    [events addObject:[OEHIDEvent axisEventWithDeviceHandler:deviceHandler timestamp:timestamp axis:OEHIDEventAxisRx value:0.0 cookie:OEGameControllerCookieRightThumbstickX]];
+    [events addObject:[OEHIDEvent axisEventWithDeviceHandler:deviceHandler timestamp:timestamp axis:OEHIDEventAxisRy value:0.0 cookie:OEGameControllerCookieRightThumbstickY]];
+    [events addObject:[OEHIDEvent triggerEventWithDeviceHandler:deviceHandler timestamp:timestamp axis:OEHIDEventAxisBrake value:0 maximum:OEGameControllerTriggerMaximum cookie:OEGameControllerCookieLeftTrigger]];
+    [events addObject:[OEHIDEvent triggerEventWithDeviceHandler:deviceHandler timestamp:timestamp axis:OEHIDEventAxisAccelerator value:0 maximum:OEGameControllerTriggerMaximum cookie:OEGameControllerCookieRightTrigger]];
+    return events;
+}
+
+- (instancetype)initWithIOHIDDevice:(IOHIDDeviceRef)device deviceDescription:(nullable OEDeviceDescription *)deviceDescription
+{
+    if((self = [super initWithIOHIDDevice:device deviceDescription:deviceDescription])) {
+        [OEGameControllerHandlers() addObject:self];
+        [self OE_addSyntheticControls];
+
+        if(@available(macOS 11.3, *))
+            GCController.shouldMonitorBackgroundEvents = YES;
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(OE_controllerDidConnect:)
+                                                     name:GCControllerDidConnectNotification
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(OE_controllerDidDisconnect:)
+                                                     name:GCControllerDidDisconnectNotification
+                                                   object:nil];
+
+        [self OE_scheduleAttachmentEvaluation];
+    }
+
+    return self;
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)disconnect
+{
+    _disconnected = YES;
+    [OEGameControllerHandlers() removeObject:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [self OE_dispatchNeutralEvents];
+    [self OE_detachGameController];
+
+    NSArray<OEGameControllerHIDDeviceHandler *> *remainingHandlers = OEGameControllerHandlers().allObjects;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        for(OEGameControllerHIDDeviceHandler *handler in remainingHandlers)
+            [handler OE_scheduleAttachmentEvaluation];
+    });
+    [super disconnect];
+}
+
+- (void)dispatchEventWithHIDValue:(IOHIDValueRef)value
+{
+}
+
+- (void)OE_addSyntheticControls
+{
+    OEControllerDescription *description = self.controllerDescription;
+    if(description == nil)
+        return;
+
+    NSTimeInterval timestamp = 0;
+    OEAddSyntheticControl(description, @"A", [OEHIDEvent buttonEventWithDeviceHandler:self timestamp:timestamp buttonNumber:1 state:OEHIDEventStateOn cookie:OEGameControllerCookieButtonA]);
+    OEAddSyntheticControl(description, @"B", [OEHIDEvent buttonEventWithDeviceHandler:self timestamp:timestamp buttonNumber:2 state:OEHIDEventStateOn cookie:OEGameControllerCookieButtonB]);
+    OEAddSyntheticControl(description, @"X", [OEHIDEvent buttonEventWithDeviceHandler:self timestamp:timestamp buttonNumber:3 state:OEHIDEventStateOn cookie:OEGameControllerCookieButtonX]);
+    OEAddSyntheticControl(description, @"Y", [OEHIDEvent buttonEventWithDeviceHandler:self timestamp:timestamp buttonNumber:4 state:OEHIDEventStateOn cookie:OEGameControllerCookieButtonY]);
+    OEAddSyntheticControl(description, @"Left Shoulder", [OEHIDEvent buttonEventWithDeviceHandler:self timestamp:timestamp buttonNumber:5 state:OEHIDEventStateOn cookie:OEGameControllerCookieLeftShoulder]);
+    OEAddSyntheticControl(description, @"Right Shoulder", [OEHIDEvent buttonEventWithDeviceHandler:self timestamp:timestamp buttonNumber:6 state:OEHIDEventStateOn cookie:OEGameControllerCookieRightShoulder]);
+    OEAddSyntheticControl(description, @"View", [OEHIDEvent buttonEventWithDeviceHandler:self timestamp:timestamp buttonNumber:7 state:OEHIDEventStateOn cookie:OEGameControllerCookieButtonOptions]);
+    OEAddSyntheticControl(description, @"Menu", [OEHIDEvent buttonEventWithDeviceHandler:self timestamp:timestamp buttonNumber:8 state:OEHIDEventStateOn cookie:OEGameControllerCookieButtonMenu]);
+    OEAddSyntheticControl(description, @"Left Stick Click", [OEHIDEvent buttonEventWithDeviceHandler:self timestamp:timestamp buttonNumber:9 state:OEHIDEventStateOn cookie:OEGameControllerCookieLeftThumbstickButton]);
+    OEAddSyntheticControl(description, @"Right Stick Click", [OEHIDEvent buttonEventWithDeviceHandler:self timestamp:timestamp buttonNumber:10 state:OEHIDEventStateOn cookie:OEGameControllerCookieRightThumbstickButton]);
+    OEAddSyntheticControl(description, @"Home", [OEHIDEvent buttonEventWithDeviceHandler:self timestamp:timestamp buttonNumber:11 state:OEHIDEventStateOn cookie:OEGameControllerCookieButtonHome]);
+    OEAddSyntheticControl(description, @"D-Pad", [OEHIDEvent hatSwitchEventWithDeviceHandler:self timestamp:timestamp type:OEHIDEventHatSwitchType8Ways direction:OEHIDEventHatDirectionNull cookie:OEGameControllerCookieDPad]);
+    OEAddSyntheticControl(description, @"Left Stick X", [OEHIDEvent axisEventWithDeviceHandler:self timestamp:timestamp axis:OEHIDEventAxisX value:0.0 cookie:OEGameControllerCookieLeftThumbstickX]);
+    OEAddSyntheticControl(description, @"Left Stick Y", [OEHIDEvent axisEventWithDeviceHandler:self timestamp:timestamp axis:OEHIDEventAxisY value:0.0 cookie:OEGameControllerCookieLeftThumbstickY]);
+    OEAddSyntheticControl(description, @"Right Stick X", [OEHIDEvent axisEventWithDeviceHandler:self timestamp:timestamp axis:OEHIDEventAxisRx value:0.0 cookie:OEGameControllerCookieRightThumbstickX]);
+    OEAddSyntheticControl(description, @"Right Stick Y", [OEHIDEvent axisEventWithDeviceHandler:self timestamp:timestamp axis:OEHIDEventAxisRy value:0.0 cookie:OEGameControllerCookieRightThumbstickY]);
+    OEAddSyntheticControl(description, @"Left Trigger", [OEHIDEvent triggerEventWithDeviceHandler:self timestamp:timestamp axis:OEHIDEventAxisBrake value:0 maximum:OEGameControllerTriggerMaximum cookie:OEGameControllerCookieLeftTrigger]);
+    OEAddSyntheticControl(description, @"Right Trigger", [OEHIDEvent triggerEventWithDeviceHandler:self timestamp:timestamp axis:OEHIDEventAxisAccelerator value:0 maximum:OEGameControllerTriggerMaximum cookie:OEGameControllerCookieRightTrigger]);
+}
+
+- (void)OE_scheduleAttachmentEvaluation
+{
+    if(_disconnected || _gameController != nil)
+        return;
+
+    if(!NSThread.isMainThread) {
+        __weak typeof(self) weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf OE_scheduleAttachmentEvaluation];
+        });
+        return;
+    }
+
+    NSUInteger generation = ++_attachmentEvaluationGeneration;
+    __weak typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 100 * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
+        OEGameControllerHIDDeviceHandler *strongSelf = weakSelf;
+        if(strongSelf != nil && generation == strongSelf->_attachmentEvaluationGeneration)
+            [strongSelf OE_attachAvailableGameController];
+    });
+}
+
+- (void)OE_attachAvailableGameController
+{
+    if(_disconnected || _gameController != nil)
+        return;
+
+    if(!NSThread.isMainThread) {
+        [self OE_scheduleAttachmentEvaluation];
+        return;
+    }
+
+    NSUInteger waitingHandlerCount = 0;
+    for(OEGameControllerHIDDeviceHandler *handler in OEGameControllerHandlers()) {
+        if(!handler->_disconnected && handler->_gameController == nil)
+            waitingHandlerCount++;
+    }
+
+    BOOL hasExclusiveGameControllerSupportedHIDDevice =
+        [[OEDeviceManager sharedDeviceManager] OE_hasSingleGameControllerSupportedHIDDeviceMatchingDevice:self.device];
+
+    NSMutableArray<GCController *> *candidates = [NSMutableArray array];
+    for(GCController *controller in GCController.controllers) {
+        if([self OE_isEligibleGameController:controller])
+            [candidates addObject:controller];
+    }
+
+    GCController *controller = [OEGameControllerHIDDeviceHandler OE_controllerForUnambiguousCandidates:candidates
+                                                                                   waitingHandlerCount:waitingHandlerCount
+                                                          hasExclusiveGameControllerSupportedHIDDevice:hasExclusiveGameControllerSupportedHIDDevice];
+    if(controller != nil)
+        [self OE_tryAttachGameController:controller];
+}
+
+- (BOOL)OE_isEligibleGameController:(GCController *)controller
+{
+    GCExtendedGamepad *gamepad = controller.extendedGamepad;
+    if(gamepad == nil)
+        return NO;
+
+    if(@available(macOS 11.0, *)) {
+        if(controller.isSnapshot)
+            return NO;
+        if(![gamepad isKindOfClass:GCXboxGamepad.class])
+            return NO;
+
+    } else {
+        return NO;
+    }
+
+    OEGameControllerHIDDeviceHandler *owner = [OEGameControllerClaims() objectForKey:controller];
+    return owner == nil || owner == self;
+}
+
+- (void)OE_tryAttachGameController:(GCController *)controller
+{
+    if(_disconnected || _gameController != nil || !NSThread.isMainThread)
+        return;
+
+    if(![self OE_isEligibleGameController:controller])
+        return;
+
+    GCExtendedGamepad *gamepad = controller.extendedGamepad;
+
+    [OEGameControllerClaims() setObject:self forKey:controller];
+    _gameController = controller;
+    _extendedGamepad = gamepad;
+    controller.handlerQueue = dispatch_get_main_queue();
+    NSUInteger attachmentGeneration = ++_attachmentGeneration;
+
+    __weak typeof(self) weakSelf = self;
+    _gamepadValueChangedHandler = ^(GCExtendedGamepad *changedGamepad, GCControllerElement *changedElement) {
+        OEGameControllerHIDDeviceHandler *strongSelf = weakSelf;
+        if(strongSelf == nil ||
+           ![OEGameControllerHIDDeviceHandler OE_shouldDispatchChangedGamepad:changedGamepad
+                                                                currentGamepad:strongSelf->_extendedGamepad
+                                                                  disconnected:strongSelf->_disconnected
+                                                    capturedAttachmentGeneration:attachmentGeneration
+                                                     currentAttachmentGeneration:strongSelf->_attachmentGeneration])
+            return;
+
+        NSArray<OEHIDEvent *> *events = [OEGameControllerHIDDeviceHandler OE_eventsForExtendedGamepad:changedGamepad
+                                                                                         changedElement:changedElement
+                                                                                          deviceHandler:strongSelf];
+        for(OEHIDEvent *event in events)
+            [strongSelf dispatchEvent:event];
+    };
+    _extendedGamepad.valueChangedHandler = _gamepadValueChangedHandler;
+}
+
+- (void)OE_dispatchNeutralEvents
+{
+    if(_gameController == nil)
+        return;
+
+    for(OEHIDEvent *event in [OEGameControllerHIDDeviceHandler OE_neutralEventsWithDeviceHandler:self])
+        [self dispatchEvent:event];
+}
+
+- (void)OE_detachGameController
+{
+    if(_gameController == nil)
+        return;
+
+    ++_attachmentGeneration;
+
+    if(_extendedGamepad.valueChangedHandler == _gamepadValueChangedHandler)
+        _extendedGamepad.valueChangedHandler = nil;
+
+    if([OEGameControllerClaims() objectForKey:_gameController] == self)
+        [OEGameControllerClaims() removeObjectForKey:_gameController];
+
+    _gamepadValueChangedHandler = nil;
+    _extendedGamepad = nil;
+    _gameController = nil;
+}
+
+- (void)OE_controllerDidConnect:(NSNotification *)notification
+{
+    [self OE_scheduleAttachmentEvaluation];
+}
+
+- (void)OE_controllerDidDisconnect:(NSNotification *)notification
+{
+    GCController *controller = notification.object;
+    if(!NSThread.isMainThread) {
+        __weak typeof(self) weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf OE_controllerDidDisconnect:notification];
+        });
+        return;
+    }
+
+    if(controller == _gameController) {
+        [self OE_dispatchNeutralEvents];
+        [self OE_detachGameController];
+    }
+
+    [self OE_scheduleAttachmentEvaluation];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceHandler.m
+++ b/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceHandler.m
@@ -25,6 +25,7 @@
  */
 
 #import "OEHIDDeviceHandler.h"
+#import "OEHIDDeviceHandler_Internal.h"
 #import "OEControllerDescription.h"
 #import "OEDeviceDescription.h"
 #import "OEControlDescription.h"
@@ -187,7 +188,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isKeyboardDevice;
 {
-    return IOHIDDeviceConformsTo(_device, kHIDPage_GenericDesktop, kHIDUsage_GD_Keyboard);
+    return OEHIDDeviceIsKeyboardOnly(_device);
 }
 
 - (BOOL)isFunctionKeyPressed

--- a/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceHandler_Internal.h
+++ b/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceHandler_Internal.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, OpenEmu Team
+// Copyright (c) 2026, OpenEmu Team
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -22,12 +22,18 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#import "OEDeviceManager.h"
+#import <Foundation/Foundation.h>
+#import <IOKit/hid/IOHIDLib.h>
+#import <IOKit/hid/IOHIDUsageTables.h>
 
-@interface OEDeviceManager ()
+NS_INLINE BOOL OEHIDDeviceConformanceIsKeyboardOnly(BOOL isKeyboard, BOOL isJoystick, BOOL isGamepad)
+{
+    return isKeyboard && !isJoystick && !isGamepad;
+}
 
-- (void)OE_removeDeviceHandler:(__kindof OEDeviceHandler *)handler;
-- (BOOL)OE_hasSingleGameControllerSupportedHIDDeviceMatchingDevice:(IOHIDDeviceRef)device;
-
-@end
-
+NS_INLINE BOOL OEHIDDeviceIsKeyboardOnly(IOHIDDeviceRef device)
+{
+    return OEHIDDeviceConformanceIsKeyboardOnly(IOHIDDeviceConformsTo(device, kHIDPage_GenericDesktop, kHIDUsage_GD_Keyboard),
+                                                IOHIDDeviceConformsTo(device, kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick),
+                                                IOHIDDeviceConformsTo(device, kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad));
+}

--- a/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceParser.m
+++ b/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceParser.m
@@ -31,6 +31,7 @@
 #import "OEControlDescription.h"
 #import "OEControlDescription.h"
 #import "OEDeviceDescription.h"
+#import "OEGameControllerHIDDeviceHandler.h"
 #import "OEMultiHIDDeviceHandler.h"
 #import "OEPS3HIDDeviceHandler.h"
 #import "OEPS4HIDDeviceHandler.h"
@@ -319,7 +320,8 @@ typedef NS_ENUM(NSInteger, OEElementType) {
         return nil;
 
     if([rootJoysticks count] == 1) {
-        _OEHIDDeviceAttributes *attributes = [[_OEHIDDeviceAttributes alloc] initWithDeviceHandlerClass:[OEHIDDeviceHandler class]];
+        Class handlerClass = [OEGameControllerHIDDeviceHandler canHandleDevice:device] ? [OEGameControllerHIDDeviceHandler class] : [OEHIDDeviceHandler class];
+        _OEHIDDeviceAttributes *attributes = [[_OEHIDDeviceAttributes alloc] initWithDeviceHandlerClass:handlerClass];
 
         [self OE_parseJoystickElement:VALUE_TO_ELEM(rootJoysticks[0]) intoControllerDescription:controllerDesc attributes:attributes deviceIdentifier:nil usingElementTree:tree];
 

--- a/OpenEmu-SDK/OpenEmuSystemTests/OEGameControllerHIDDeviceHandlerTests.m
+++ b/OpenEmu-SDK/OpenEmuSystemTests/OEGameControllerHIDDeviceHandlerTests.m
@@ -1,0 +1,300 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <XCTest/XCTest.h>
+#import <GameController/GameController.h>
+#import <objc/runtime.h>
+#import <OpenEmuSystem/OpenEmuSystem.h>
+#import "../OpenEmuSystem/OEGameControllerHIDDeviceHandler.h"
+#import "../OpenEmuSystem/OEHIDEvent_Internal.h"
+
+@interface OEGameControllerHIDDeviceHandlerTests : XCTestCase
+@end
+
+@implementation OEGameControllerHIDDeviceHandlerTests
+
+- (OEHIDEvent *)eventWithCookie:(NSUInteger)cookie inEvents:(NSArray<OEHIDEvent *> *)events
+{
+    for(OEHIDEvent *event in events) {
+        if(event.cookie == cookie)
+            return event;
+    }
+
+    return nil;
+}
+
+- (NSArray<OEHIDEvent *> *)eventsForGamepad:(GCExtendedGamepad *)gamepad changedElement:(GCControllerElement *)element
+{
+    return [OEGameControllerHIDDeviceHandler OE_eventsForExtendedGamepad:gamepad
+                                                          changedElement:element
+                                                           deviceHandler:nil];
+}
+
+- (void)testOnlyTheAppleSupportedBluetoothEliteDescriptorUsesTheBridge
+{
+    XCTAssertTrue([OEGameControllerHIDDeviceHandler OE_matchesVendorID:0x045E
+                                                               productID:0x0B05
+                                                  gameControllerSupported:YES]);
+    XCTAssertFalse([OEGameControllerHIDDeviceHandler OE_matchesVendorID:0x045E
+                                                                productID:0x0B05
+                                                   gameControllerSupported:NO]);
+    XCTAssertFalse([OEGameControllerHIDDeviceHandler OE_matchesVendorID:0x045E
+                                                                productID:0x0B00
+                                                   gameControllerSupported:YES]);
+    XCTAssertFalse([OEGameControllerHIDDeviceHandler OE_matchesVendorID:0x045E
+                                                                productID:0x0B06
+                                                   gameControllerSupported:YES]);
+    XCTAssertFalse([OEGameControllerHIDDeviceHandler OE_matchesVendorID:0x054C
+                                                                productID:0x0CE6
+                                                   gameControllerSupported:YES]);
+}
+
+- (void)testSyntheticControlCookiesAreStableUniqueAndNonzero
+{
+    NSArray<NSNumber *> *cookies = @[
+        @(OEGameControllerCookieButtonA),
+        @(OEGameControllerCookieButtonB),
+        @(OEGameControllerCookieButtonX),
+        @(OEGameControllerCookieButtonY),
+        @(OEGameControllerCookieLeftShoulder),
+        @(OEGameControllerCookieRightShoulder),
+        @(OEGameControllerCookieButtonOptions),
+        @(OEGameControllerCookieButtonMenu),
+        @(OEGameControllerCookieLeftThumbstickButton),
+        @(OEGameControllerCookieRightThumbstickButton),
+        @(OEGameControllerCookieButtonHome),
+        @(OEGameControllerCookieDPad),
+        @(OEGameControllerCookieLeftThumbstickX),
+        @(OEGameControllerCookieLeftThumbstickY),
+        @(OEGameControllerCookieRightThumbstickX),
+        @(OEGameControllerCookieRightThumbstickY),
+        @(OEGameControllerCookieLeftTrigger),
+        @(OEGameControllerCookieRightTrigger),
+    ];
+
+    XCTAssertFalse([cookies containsObject:@0]);
+    XCTAssertEqual([NSSet setWithArray:cookies].count, cookies.count);
+}
+
+- (void)testFaceAndShoulderButtonsConvertToStableButtonEvents
+{
+    GCExtendedGamepad *gamepad = [GCController controllerWithExtendedGamepad].extendedGamepad;
+    NSArray<GCControllerButtonInput *> *buttons = @[
+        gamepad.buttonA,
+        gamepad.buttonB,
+        gamepad.buttonX,
+        gamepad.buttonY,
+        gamepad.leftShoulder,
+        gamepad.rightShoulder,
+    ];
+    NSArray<NSNumber *> *cookies = @[
+        @(OEGameControllerCookieButtonA),
+        @(OEGameControllerCookieButtonB),
+        @(OEGameControllerCookieButtonX),
+        @(OEGameControllerCookieButtonY),
+        @(OEGameControllerCookieLeftShoulder),
+        @(OEGameControllerCookieRightShoulder),
+    ];
+
+    [buttons enumerateObjectsUsingBlock:^(GCControllerButtonInput *button, NSUInteger index, BOOL *stop) {
+        [button setValue:1.0];
+        OEHIDEvent *pressed = [self eventWithCookie:cookies[index].unsignedIntegerValue
+                                          inEvents:[self eventsForGamepad:gamepad changedElement:button]];
+        XCTAssertEqual(pressed.type, OEHIDEventTypeButton);
+        XCTAssertEqual(pressed.state, OEHIDEventStateOn);
+
+        [button setValue:0.0];
+        OEHIDEvent *released = [self eventWithCookie:cookies[index].unsignedIntegerValue
+                                           inEvents:[self eventsForGamepad:gamepad changedElement:button]];
+        XCTAssertEqual(released.state, OEHIDEventStateOff);
+    }];
+}
+
+- (void)testDPadConvertsCardinalDiagonalAndNeutralDirections
+{
+    GCExtendedGamepad *gamepad = [GCController controllerWithExtendedGamepad].extendedGamepad;
+
+    [gamepad.dpad setValueForXAxis:0.0 yAxis:1.0];
+    OEHIDEvent *north = [self eventWithCookie:OEGameControllerCookieDPad
+                                    inEvents:[self eventsForGamepad:gamepad changedElement:gamepad.dpad]];
+    XCTAssertEqual(north.hatDirection, OEHIDEventHatDirectionNorth);
+
+    [gamepad.dpad setValueForXAxis:1.0 yAxis:1.0];
+    OEHIDEvent *northEast = [self eventWithCookie:OEGameControllerCookieDPad
+                                        inEvents:[self eventsForGamepad:gamepad changedElement:gamepad.dpad.right]];
+    XCTAssertEqual(northEast.hatDirection, OEHIDEventHatDirectionNorth | OEHIDEventHatDirectionEast);
+
+    [gamepad.dpad setValueForXAxis:0.0 yAxis:0.0];
+    OEHIDEvent *neutral = [self eventWithCookie:OEGameControllerCookieDPad
+                                      inEvents:[self eventsForGamepad:gamepad changedElement:gamepad.dpad.xAxis]];
+    XCTAssertEqual(neutral.hatDirection, OEHIDEventHatDirectionNull);
+}
+
+- (void)testThumbsticksConvertNormalizedAxes
+{
+    GCExtendedGamepad *gamepad = [GCController controllerWithExtendedGamepad].extendedGamepad;
+    [gamepad.leftThumbstick setValueForXAxis:-0.75 yAxis:0.5];
+    [gamepad.rightThumbstick setValueForXAxis:0.25 yAxis:-1.0];
+
+    NSArray<OEHIDEvent *> *leftEvents = [self eventsForGamepad:gamepad changedElement:gamepad.leftThumbstick];
+    XCTAssertEqualWithAccuracy([self eventWithCookie:OEGameControllerCookieLeftThumbstickX inEvents:leftEvents].value, -0.75, 0.001);
+    XCTAssertEqualWithAccuracy([self eventWithCookie:OEGameControllerCookieLeftThumbstickY inEvents:leftEvents].value, 0.5, 0.001);
+
+    NSArray<OEHIDEvent *> *rightEvents = [self eventsForGamepad:gamepad changedElement:gamepad.rightThumbstick.yAxis];
+    XCTAssertNil([self eventWithCookie:OEGameControllerCookieRightThumbstickX inEvents:rightEvents]);
+    XCTAssertEqualWithAccuracy([self eventWithCookie:OEGameControllerCookieRightThumbstickY inEvents:rightEvents].value, -1.0, 0.001);
+}
+
+- (void)testTriggersUsePositiveNormalizedTriggerEvents
+{
+    GCExtendedGamepad *gamepad = [GCController controllerWithExtendedGamepad].extendedGamepad;
+    [gamepad.leftTrigger setValue:0.75];
+    [gamepad.rightTrigger setValue:0.25];
+
+    OEHIDEvent *left = [self eventWithCookie:OEGameControllerCookieLeftTrigger
+                                   inEvents:[self eventsForGamepad:gamepad changedElement:gamepad.leftTrigger]];
+    OEHIDEvent *right = [self eventWithCookie:OEGameControllerCookieRightTrigger
+                                    inEvents:[self eventsForGamepad:gamepad changedElement:gamepad.rightTrigger]];
+
+    XCTAssertEqual(left.type, OEHIDEventTypeTrigger);
+    XCTAssertEqual(left.direction, OEHIDEventAxisDirectionPositive);
+    XCTAssertEqualWithAccuracy(left.value, 0.75, 0.001);
+    XCTAssertEqualWithAccuracy(right.value, 0.25, 0.001);
+}
+
+- (void)testMenuOptionsHomeAndStickClicksConvertToButtons
+{
+    GCExtendedGamepad *gamepad = [GCController controllerWithExtendedGamepad].extendedGamepad;
+    NSArray<GCControllerButtonInput *> *buttons = @[
+        gamepad.buttonOptions,
+        gamepad.buttonMenu,
+        gamepad.leftThumbstickButton,
+        gamepad.rightThumbstickButton,
+        gamepad.buttonHome,
+    ];
+    NSArray<NSNumber *> *cookies = @[
+        @(OEGameControllerCookieButtonOptions),
+        @(OEGameControllerCookieButtonMenu),
+        @(OEGameControllerCookieLeftThumbstickButton),
+        @(OEGameControllerCookieRightThumbstickButton),
+        @(OEGameControllerCookieButtonHome),
+    ];
+
+    [buttons enumerateObjectsUsingBlock:^(GCControllerButtonInput *button, NSUInteger index, BOOL *stop) {
+        XCTAssertNotNil(button);
+        [button setValue:1.0];
+        OEHIDEvent *event = [self eventWithCookie:cookies[index].unsignedIntegerValue
+                                        inEvents:[self eventsForGamepad:gamepad changedElement:button]];
+        XCTAssertEqual(event.type, OEHIDEventTypeButton);
+        XCTAssertEqual(event.state, OEHIDEventStateOn);
+    }];
+}
+
+- (void)testUnrelatedElementProducesNoSyntheticEvents
+{
+    GCExtendedGamepad *first = [GCController controllerWithExtendedGamepad].extendedGamepad;
+    GCExtendedGamepad *second = [GCController controllerWithExtendedGamepad].extendedGamepad;
+
+    XCTAssertEqual([self eventsForGamepad:first changedElement:second.buttonA].count, 0);
+}
+
+- (void)testSubclassOverridesRawHIDDispatchToPreventDuplicateEvents
+{
+    Method baseMethod = class_getInstanceMethod(OEHIDDeviceHandler.class, @selector(dispatchEventWithHIDValue:));
+    Method bridgeMethod = class_getInstanceMethod(OEGameControllerHIDDeviceHandler.class, @selector(dispatchEventWithHIDValue:));
+
+    XCTAssertNotEqual(method_getImplementation(baseMethod), method_getImplementation(bridgeMethod));
+}
+
+- (void)testControllerClaimRejectsAmbiguityAndAcceptsAfterResolution
+{
+    GCController *first = [GCController controllerWithExtendedGamepad];
+    GCController *second = [GCController controllerWithExtendedGamepad];
+    NSArray<GCController *> *ambiguousCandidates = @[first, second];
+    NSArray<GCController *> *resolvedCandidates = @[first];
+
+    XCTAssertNil([OEGameControllerHIDDeviceHandler OE_controllerForUnambiguousCandidates:ambiguousCandidates
+                                                                     waitingHandlerCount:1
+                                  hasExclusiveGameControllerSupportedHIDDevice:YES]);
+    XCTAssertNil([OEGameControllerHIDDeviceHandler OE_controllerForUnambiguousCandidates:resolvedCandidates
+                                                                     waitingHandlerCount:2
+                                  hasExclusiveGameControllerSupportedHIDDevice:YES]);
+    XCTAssertNil([OEGameControllerHIDDeviceHandler OE_controllerForUnambiguousCandidates:resolvedCandidates
+                                                                     waitingHandlerCount:1
+                                  hasExclusiveGameControllerSupportedHIDDevice:NO]);
+    XCTAssertNil([OEGameControllerHIDDeviceHandler OE_controllerForUnambiguousCandidates:@[]
+                                                                     waitingHandlerCount:1
+                                  hasExclusiveGameControllerSupportedHIDDevice:YES]);
+    XCTAssertEqual([OEGameControllerHIDDeviceHandler OE_controllerForUnambiguousCandidates:resolvedCandidates
+                                                                      waitingHandlerCount:1
+                                   hasExclusiveGameControllerSupportedHIDDevice:YES],
+                   first);
+}
+
+- (void)testDisconnectNeutralEventsReleaseEverySyntheticControl
+{
+    NSArray<OEHIDEvent *> *events = [OEGameControllerHIDDeviceHandler OE_neutralEventsWithDeviceHandler:nil];
+    NSMutableSet<NSNumber *> *cookies = [NSMutableSet set];
+
+    XCTAssertEqual(events.count, 18);
+    for(OEHIDEvent *event in events) {
+        [cookies addObject:@(event.cookie)];
+        if(event.type == OEHIDEventTypeButton)
+            XCTAssertEqual(event.state, OEHIDEventStateOff);
+        else if(event.type == OEHIDEventTypeHatSwitch)
+            XCTAssertEqual(event.hatDirection, OEHIDEventHatDirectionNull);
+        else
+            XCTAssertEqualWithAccuracy(event.value, 0.0, 0.001);
+    }
+    XCTAssertEqual(cookies.count, events.count);
+}
+
+- (void)testStaleQueuedCallbacksAreRejectedAfterDetach
+{
+    GCExtendedGamepad *first = [GCController controllerWithExtendedGamepad].extendedGamepad;
+    GCExtendedGamepad *second = [GCController controllerWithExtendedGamepad].extendedGamepad;
+
+    XCTAssertTrue([OEGameControllerHIDDeviceHandler OE_shouldDispatchChangedGamepad:first
+                                                                      currentGamepad:first
+                                                                        disconnected:NO
+                                                  capturedAttachmentGeneration:4
+                                                   currentAttachmentGeneration:4]);
+    XCTAssertFalse([OEGameControllerHIDDeviceHandler OE_shouldDispatchChangedGamepad:first
+                                                                       currentGamepad:first
+                                                                         disconnected:YES
+                                                   capturedAttachmentGeneration:4
+                                                    currentAttachmentGeneration:4]);
+    XCTAssertFalse([OEGameControllerHIDDeviceHandler OE_shouldDispatchChangedGamepad:first
+                                                                       currentGamepad:second
+                                                                         disconnected:NO
+                                                   capturedAttachmentGeneration:4
+                                                    currentAttachmentGeneration:4]);
+    XCTAssertFalse([OEGameControllerHIDDeviceHandler OE_shouldDispatchChangedGamepad:first
+                                                                       currentGamepad:first
+                                                                         disconnected:NO
+                                                   capturedAttachmentGeneration:4
+                                                    currentAttachmentGeneration:5]);
+}
+
+@end

--- a/OpenEmu-SDK/OpenEmuSystemTests/OEHIDDeviceClassificationTests.m
+++ b/OpenEmu-SDK/OpenEmuSystemTests/OEHIDDeviceClassificationTests.m
@@ -1,0 +1,179 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <XCTest/XCTest.h>
+#import <OpenEmuSystem/OpenEmuSystem.h>
+#import "../OpenEmuSystem/OEHIDDeviceHandler_Internal.h"
+
+@interface OEDeviceManager (ClassificationTesting)
+- (void)OE_addDeviceHandler:(OEDeviceHandler *)handler;
+- (BOOL)OE_hasDeviceHandlerForDeviceRef:(nullable IOHIDDeviceRef)deviceRef
+                        registryEntryID:(nullable NSNumber *)registryEntryID;
+- (nullable NSNumber *)OE_registryEntryIDForDeviceHandler:(OEDeviceHandler *)handler;
+@end
+
+@interface OEClassificationTestDeviceManager : OEDeviceManager {
+    NSMapTable<OEDeviceHandler *, NSNumber *> *_testRegistryEntryIDs;
+}
+- (void)setRegistryEntryID:(NSNumber *)registryEntryID forDeviceHandler:(OEDeviceHandler *)handler;
+@end
+
+@implementation OEClassificationTestDeviceManager
+
+- (instancetype)init
+{
+    if((self = [super init]))
+        _testRegistryEntryIDs = [NSMapTable strongToStrongObjectsMapTable];
+
+    return self;
+}
+
+- (void)OE_setUpCallbacks
+{
+}
+
+- (void)setRegistryEntryID:(NSNumber *)registryEntryID forDeviceHandler:(OEDeviceHandler *)handler
+{
+    [_testRegistryEntryIDs setObject:registryEntryID forKey:handler];
+}
+
+- (NSNumber *)OE_registryEntryIDForDeviceHandler:(OEDeviceHandler *)handler
+{
+    return [_testRegistryEntryIDs objectForKey:handler];
+}
+
+@end
+
+@interface OEClassificationTestControllerDescription : OEControllerDescription
+@end
+
+@implementation OEClassificationTestControllerDescription
+
+- (NSUInteger)numberOfControls
+{
+    return 1;
+}
+
+@end
+
+@interface OEClassificationTestDeviceHandler : OEDeviceHandler
+- (instancetype)initWithIdentifier:(NSString *)identifier
+                       isKeyboard:(BOOL)isKeyboard
+                       isJoystick:(BOOL)isJoystick
+                        isGamepad:(BOOL)isGamepad;
+@end
+
+@implementation OEClassificationTestDeviceHandler {
+    NSString *_testIdentifier;
+    BOOL _testIsKeyboard;
+    BOOL _testIsJoystick;
+    BOOL _testIsGamepad;
+    OEControllerDescription *_testControllerDescription;
+}
+
+- (instancetype)initWithIdentifier:(NSString *)identifier
+                       isKeyboard:(BOOL)isKeyboard
+                       isJoystick:(BOOL)isJoystick
+                        isGamepad:(BOOL)isGamepad
+{
+    if((self = [super initWithDeviceDescription:nil])) {
+        _testIdentifier = [identifier copy];
+        _testIsKeyboard = isKeyboard;
+        _testIsJoystick = isJoystick;
+        _testIsGamepad = isGamepad;
+        _testControllerDescription = [[OEClassificationTestControllerDescription alloc] init];
+    }
+
+    return self;
+}
+
+- (OEControllerDescription *)controllerDescription
+{
+    return _testControllerDescription;
+}
+
+- (NSString *)uniqueIdentifier
+{
+    return _testIdentifier;
+}
+
+- (BOOL)isKeyboardDevice
+{
+    return OEHIDDeviceConformanceIsKeyboardOnly(_testIsKeyboard, _testIsJoystick, _testIsGamepad);
+}
+
+@end
+
+@interface OEHIDDeviceClassificationTests : XCTestCase
+@end
+
+@implementation OEHIDDeviceClassificationTests
+
+- (void)testOnlyPureKeyboardsUseTheKeyboardRole
+{
+    XCTAssertTrue(OEHIDDeviceConformanceIsKeyboardOnly(YES, NO, NO));
+    XCTAssertFalse(OEHIDDeviceConformanceIsKeyboardOnly(YES, YES, NO));
+    XCTAssertFalse(OEHIDDeviceConformanceIsKeyboardOnly(YES, NO, YES));
+    XCTAssertFalse(OEHIDDeviceConformanceIsKeyboardOnly(NO, NO, NO));
+}
+
+- (void)testHybridGamepadRegistersAsControllerWhilePureKeyboardStaysKeyboard
+{
+    OEClassificationTestDeviceManager *manager = [[OEClassificationTestDeviceManager alloc] init];
+    OEClassificationTestDeviceHandler *hybridGamepad = [[OEClassificationTestDeviceHandler alloc] initWithIdentifier:@"hybrid-gamepad"
+                                                                                                          isKeyboard:YES
+                                                                                                          isJoystick:NO
+                                                                                                           isGamepad:YES];
+    OEClassificationTestDeviceHandler *pureKeyboard = [[OEClassificationTestDeviceHandler alloc] initWithIdentifier:@"pure-keyboard"
+                                                                                                         isKeyboard:YES
+                                                                                                         isJoystick:NO
+                                                                                                          isGamepad:NO];
+
+    [manager OE_addDeviceHandler:hybridGamepad];
+    [manager OE_addDeviceHandler:pureKeyboard];
+
+    XCTAssertTrue([manager.controllerDeviceHandlers containsObject:hybridGamepad]);
+    XCTAssertFalse([manager.keyboardDeviceHandlers containsObject:hybridGamepad]);
+    XCTAssertTrue([manager.keyboardDeviceHandlers containsObject:pureKeyboard]);
+    XCTAssertFalse([manager.controllerDeviceHandlers containsObject:pureKeyboard]);
+}
+
+- (void)testRegistryIdentityDetectsDuplicateHIDDeviceWrappers
+{
+    OEClassificationTestDeviceManager *manager = [[OEClassificationTestDeviceManager alloc] init];
+    OEClassificationTestDeviceHandler *registeredHandler = [[OEClassificationTestDeviceHandler alloc] initWithIdentifier:@"registered-gamepad"
+                                                                                                               isKeyboard:NO
+                                                                                                               isJoystick:NO
+                                                                                                                isGamepad:YES];
+    NSNumber *registryEntryID = @(0x1000189EC);
+
+    [manager setRegistryEntryID:registryEntryID forDeviceHandler:registeredHandler];
+    [manager OE_addDeviceHandler:registeredHandler];
+
+    XCTAssertTrue([manager OE_hasDeviceHandlerForDeviceRef:NULL registryEntryID:registryEntryID]);
+    XCTAssertFalse([manager OE_hasDeviceHandlerForDeviceRef:NULL registryEntryID:@(0x1000189ED)]);
+    XCTAssertFalse([manager OE_hasDeviceHandlerForDeviceRef:NULL registryEntryID:nil]);
+}
+
+@end


### PR DESCRIPTION
## Summary

- classify hybrid keyboard/gamepad HID devices as game controllers instead of keyboard-only devices
- deduplicate multiple `IOHIDDeviceRef` wrappers that resolve to the same IOKit registry service
- bridge the exact Bluetooth Xbox Elite Series 2 device (`045e:0b05`) through Apple’s GameController framework
- expose stable OpenEmu button, trigger, axis, and hat events while suppressing duplicate raw-HID dispatch
- fail closed when controller identity is ambiguous, release mapped inputs on disconnect, and reject stale queued callbacks after detach

## Root cause

The Elite Series 2 Bluetooth descriptor advertises both Keyboard and GamePad collections. OpenEmu’s keyboard-only routing treated that hybrid device as a keyboard, and the same physical controller could also appear through multiple HID wrappers. After correcting classification and deduplication, raw HID still did not provide usable game input because macOS owns this supported controller through GameController.

The new handler is deliberately limited to the live-proven Bluetooth VID/PID and requires GameController support plus an unambiguous one-controller/one-handler/raw-device match. It does not change the separate wired `045e:0b00` path handled by #641.

## Validation

- focused `OEGameControllerHIDDeviceHandlerTests` and `OEHIDDeviceClassificationTests`
- full `OpenEmuSystem` test suite
- `xcodebuild analyze` with only pre-existing baseline warnings
- full arm64 Debug OpenEmu workspace build
- `GameController.framework` linkage and staged-diff integrity checks
- independent final review of identity, lifecycle, neutralization, and stale-callback paths

The earlier classification/dedup build was live-verified to register exactly one Elite HID handler. Final physical button/mapping and disconnect/reconnect verification remains pending, so this PR is intentionally opened as a draft.

Addresses #642
