### PR TITLE
Feature: Cheat Search

### DIFF
--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -28,6 +28,8 @@
 #import <OpenGL/gl.h>
 #import "BSNESGameCore.h"
 #import "OESNESSystemResponderClient.h"
+#import <OpenEmuBase/OESystemConstants.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
 
 #define SYS_PARAM_H__BSD BSD
 #undef BSD
@@ -379,7 +381,7 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
 
 - (void)setCheat:(NSString *)code setType:(NSString *)type setEnabled:(BOOL)enabled
 {
-    if ([type isEqual:@"Action Replay"])
+    if ([type isEqual:OECheatTypeActionReplay] || [type isEqual:OECheatTypeRaw])
         code = [code stringByReplacingOccurrencesOfString:@":" withString:@""];
     NSArray <NSString *> *codes = [code componentsSeparatedByString:@"+"];
     if (enabled)
@@ -684,5 +686,19 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
     return Emulator::audio.channels();
 }
 
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+    const NSUInteger wramSize = 128 * 1024;
+    NSMutableData *data = [NSMutableData dataWithLength:wramSize];
+    uint8_t *bytes = (uint8_t *)data.mutableBytes;
+    for (NSUInteger i = 0; i < wramSize; i++) {
+        bytes[i] = emulator->read(0x7E0000 + i);
+    }
+    OEMemoryRegionDescriptor *wram = [OEMemoryRegionDescriptor descriptorWithName:@"WRAM"
+                                                                          address:0x7E0000
+                                                                     addressBytes:3
+                                                                             data:data];
+    return @[wram];
+}
 
 @end

--- a/BSNES/BSNESGameCore.mm
+++ b/BSNES/BSNESGameCore.mm
@@ -688,6 +688,7 @@ static void bsnes_rc_event_handler(const rc_client_event_t *event, rc_client_t *
 
 - (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
 {
+    if (!emulator) return @[];
     const NSUInteger wramSize = 128 * 1024;
     NSMutableData *data = [NSMutableData dataWithLength:wramSize];
     uint8_t *bytes = (uint8_t *)data.mutableBytes;

--- a/BSNES/Info.plist
+++ b/BSNES/Info.plist
@@ -36,6 +36,8 @@
 			<integer>1</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsDisplayModeChange</key>
 			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>

--- a/CrabEmu/Info.plist
+++ b/CrabEmu/Info.plist
@@ -99,6 +99,9 @@
 	<key>OESystemIdentifiers</key>
 	<array>
 		<string>openemu.system.colecovision</string>
+		<string>openemu.system.gg</string>
+		<string>openemu.system.sg1000</string>
+		<string>openemu.system.sms</string>
 	</array>
 	<key>SUEnableAutomaticChecks</key>
 	<string>1</string>

--- a/CrabEmu/Info.plist
+++ b/CrabEmu/Info.plist
@@ -34,6 +34,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsRewinding</key>
 			<true/>
 			<key>OERequiredFiles</key>
@@ -58,6 +60,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsRewinding</key>
 			<true/>
 		</dict>
@@ -69,6 +73,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsRewinding</key>
 			<true/>
 		</dict>
@@ -79,6 +85,8 @@
 			<key>OEGameCoreRewindInterval</key>
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
+			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
 			<true/>
 			<key>OEGameCoreSupportsRewinding</key>
 			<true/>

--- a/CrabEmu/SMSGameCore.m
+++ b/CrabEmu/SMSGameCore.m
@@ -481,8 +481,8 @@ const int ColecoVisionMap[] = {COLECOVISION_UP, COLECOVISION_DOWN, COLECOVISION_
                     uint32_t outAddress, outValue;
                     NSScanner *scanAddress = [NSScanner scannerWithString:address];
                     NSScanner *scanValue = [NSScanner scannerWithString:value];
-                    [scanAddress scanHexInt:&outAddress];
-                    [scanValue scanHexInt:&outValue];
+                    if (![scanAddress scanHexInt:&outAddress] || ![scanValue scanHexInt:&outValue])
+                        continue;
 
                     sms_cheat_t *arCode = (sms_cheat_t *)malloc(sizeof(sms_cheat_t));
                     memset(arCode, 0, sizeof(sms_cheat_t));

--- a/CrabEmu/SMSGameCore.m
+++ b/CrabEmu/SMSGameCore.m
@@ -439,9 +439,8 @@ const int ColecoVisionMap[] = {COLECOVISION_UP, COLECOVISION_DOWN, COLECOVISION_
     // Remove any spaces
     code = [code stringByReplacingOccurrencesOfString:@" " withString:@""];
 
-    // Remove address-value separator
+    // Remove Game Genie dash separator (colons are handled per-code below)
     code = [code stringByReplacingOccurrencesOfString:@"-" withString:@""];
-    code = [code stringByReplacingOccurrencesOfString:@":" withString:@""];
 
     if (enabled)
         [cheatList setValue:@YES forKey:code];
@@ -461,11 +460,22 @@ const int ColecoVisionMap[] = {COLECOVISION_UP, COLECOVISION_DOWN, COLECOVISION_
             multipleCodes = [key componentsSeparatedByString:@"+"];
             for (NSString *singleCode in multipleCodes)
             {
-                if ([singleCode length] == 8)
+                // Normalize raw format (ADDR:VAL) to 8-char AR (AAAAVVVV)
+                NSString *normalized = singleCode;
+                NSRange colon = [singleCode rangeOfString:@":"];
+                if (colon.location != NSNotFound) {
+                    NSString *addr = [singleCode substringToIndex:colon.location];
+                    NSString *val = [singleCode substringFromIndex:colon.location + 1];
+                    while (addr.length < 4) addr = [@"0" stringByAppendingString:addr];
+                    while (val.length < 4) val = [@"0" stringByAppendingString:val];
+                    normalized = [addr stringByAppendingString:val];
+                }
+
+                if ([normalized length] == 8)
                 {
                     // Action Replay GG/SMS format: XXXX-YYYY
-                    NSString *address = [singleCode substringWithRange:NSMakeRange(0, 4)];
-                    NSString *value = [singleCode substringWithRange:NSMakeRange(4, 4)];
+                    NSString *address = [normalized substringWithRange:NSMakeRange(0, 4)];
+                    NSString *value = [normalized substringWithRange:NSMakeRange(4, 4)];
 
                     // Convert AR hex to int
                     uint32_t outAddress, outValue;
@@ -477,7 +487,7 @@ const int ColecoVisionMap[] = {COLECOVISION_UP, COLECOVISION_DOWN, COLECOVISION_
                     sms_cheat_t *arCode = (sms_cheat_t *)malloc(sizeof(sms_cheat_t));
                     memset(arCode, 0, sizeof(sms_cheat_t));
                     arCode->ar_code = (outAddress << 16) | outValue;
-                    strcpy(arCode->desc, [singleCode UTF8String]);
+                    strcpy(arCode->desc, [normalized UTF8String]);
                     arCode->enabled = 1;
 
                     sms_cheat_add(arCode);
@@ -497,7 +507,7 @@ const int ColecoVisionMap[] = {COLECOVISION_UP, COLECOVISION_DOWN, COLECOVISION_
     return @[
         [OEMemoryRegionDescriptor descriptorWithName:@"RAM"
                                             address:0xC000
-                                       addressBytes:3
+                                       addressBytes:2
                                                data:ramData]
     ];
 }

--- a/CrabEmu/SMSGameCore.m
+++ b/CrabEmu/SMSGameCore.m
@@ -495,7 +495,7 @@ const int ColecoVisionMap[] = {COLECOVISION_UP, COLECOVISION_DOWN, COLECOVISION_
 
     NSData *ramData = [NSData dataWithBytes:ramBase length:8 * 1024];
     return @[
-        [OEMemoryRegionDescriptor descriptorWithName:@"Work RAM"
+        [OEMemoryRegionDescriptor descriptorWithName:@"RAM"
                                             address:0xC000
                                        addressBytes:3
                                                data:ramData]

--- a/CrabEmu/SMSGameCore.m
+++ b/CrabEmu/SMSGameCore.m
@@ -26,6 +26,8 @@
 
 #import "SMSGameCore.h"
 #import <OpenEmuBase/OERingBuffer.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
+#import <OpenEmuBase/OESystemConstants.h>
 #import <OpenGL/gl.h>
 #import "OESMSSystemResponderClient.h"
 #import "OEGGSystemResponderClient.h"
@@ -41,6 +43,8 @@
 #include "colecovision.h"
 #include "colecomem.h"
 #include "cheats.h"
+
+extern uint8 *sms_read_map[256];
 #include "console.h"
 
 #if MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_13
@@ -437,6 +441,7 @@ const int ColecoVisionMap[] = {COLECOVISION_UP, COLECOVISION_DOWN, COLECOVISION_
 
     // Remove address-value separator
     code = [code stringByReplacingOccurrencesOfString:@"-" withString:@""];
+    code = [code stringByReplacingOccurrencesOfString:@":" withString:@""];
 
     if (enabled)
         [cheatList setValue:@YES forKey:code];
@@ -481,6 +486,20 @@ const int ColecoVisionMap[] = {COLECOVISION_UP, COLECOVISION_DOWN, COLECOVISION_
             }
         }
     }
+}
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+    uint8 *ramBase = sms_read_map[0xC0];
+    if (!ramBase) return @[];
+
+    NSData *ramData = [NSData dataWithBytes:ramBase length:8 * 1024];
+    return @[
+        [OEMemoryRegionDescriptor descriptorWithName:@"Work RAM"
+                                            address:0xC000
+                                       addressBytes:3
+                                               data:ramData]
+    ];
 }
 
 @end

--- a/DeSmuME/src/frontend/cocoa/openemu/Info (OpenEmu Plug-in).plist
+++ b/DeSmuME/src/frontend/cocoa/openemu/Info (OpenEmu Plug-in).plist
@@ -40,6 +40,8 @@
 		<dict>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsDisplayModeChange</key>
 			<true/>
 		</dict>

--- a/DeSmuME/src/frontend/cocoa/openemu/NDSGameCore.mm
+++ b/DeSmuME/src/frontend/cocoa/openemu/NDSGameCore.mm
@@ -1694,6 +1694,7 @@ void UpdateDisplayPropertiesFromStates(uint64_t displayModeStates, ClientDisplay
 
 - (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
 {
+	if (gameInfo.romsize == 0) return @[];
 	uint32_t ramSize = _MMU_MAIN_MEM_MASK + 1;
 	NSData *data = [NSData dataWithBytes:MMU.MAIN_MEM length:ramSize];
 	OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"Main RAM"

--- a/DeSmuME/src/frontend/cocoa/openemu/NDSGameCore.mm
+++ b/DeSmuME/src/frontend/cocoa/openemu/NDSGameCore.mm
@@ -16,6 +16,8 @@
  */
 
 #import <OpenEmuBase/OERingBuffer.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
+#include "../../../MMU.h"
 
 #import "NDSGameCore.h"
 #import "OESoundInterface.h"
@@ -1688,6 +1690,17 @@ void UpdateDisplayPropertiesFromStates(uint64_t displayModeStates, ClientDisplay
 	
 	ClientExecutionControl::UpdateNDSFrameInfoInput(_inputHandler, _ndsFrameInfo);
 	_cdp->SetHUDInfo(_clientFrameInfo, _ndsFrameInfo);
+}
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+	uint32_t ramSize = _MMU_MAIN_MEM_MASK + 1;
+	NSData *data = [NSData dataWithBytes:MMU.MAIN_MEM length:ramSize];
+	OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"Main RAM"
+	                                                                          address:0x02000000
+	                                                                     addressBytes:4
+	                                                                             data:data];
+	return @[descriptor];
 }
 
 @end

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -26,6 +26,7 @@
 
 #import "FCEUGameCore.h"
 #import <OpenEmuBase/OERingBuffer.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
 #import "OENESSystemResponderClient.h"
 #import <OpenGL/gl.h>
 
@@ -929,6 +930,16 @@ void FCEUD_PrintError(const char *s)
 void FCEUD_Message(const char *s)
 {
     NSLog(@"[FCEUX] message: %s", s);
+}
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+    NSData *data = [NSData dataWithBytes:RAM length:0x800];
+    OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"RAM"
+                                                                              address:0x0000
+                                                                         addressBytes:2
+                                                                                 data:data];
+    return @[descriptor];
 }
 
 @end

--- a/FCEU/FCEUGameCore.mm
+++ b/FCEU/FCEUGameCore.mm
@@ -934,6 +934,7 @@ void FCEUD_Message(const char *s)
 
 - (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
 {
+    if (!RAM) return @[];
     NSData *data = [NSData dataWithBytes:RAM length:0x800];
     OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"RAM"
                                                                               address:0x0000

--- a/FCEU/Info.plist
+++ b/FCEU/Info.plist
@@ -34,6 +34,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsDisplayModeChange</key>
 			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -26,6 +26,7 @@
 
 #import "GBGameCore.h"
 #import <OpenEmuBase/OERingBuffer.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
 #import "OEGBSystemResponderClient.h"
 #import <OpenGL/gl.h>
 
@@ -717,6 +718,23 @@ const int GBMap[] = {gambatte::InputGetter::UP, gambatte::InputGetter::DOWN, gam
             gb.setDmgPaletteColor(palnum, colornum, rgb32);
         }
     }
+}
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+    const NSUInteger wramSize = 0x2000;
+    NSMutableData *wramData = [NSMutableData dataWithLength:wramSize];
+    uint8_t *bytes = (uint8_t *)wramData.mutableBytes;
+    for (NSUInteger i = 0; i < wramSize; i++) {
+        bytes[i] = gb.busRead8(0xC000 + i);
+    }
+
+    return @[
+        [OEMemoryRegionDescriptor descriptorWithName:@"WRAM"
+                                            address:0xC000
+                                       addressBytes:2
+                                               data:wramData]
+    ];
 }
 
 @end

--- a/Gambatte/GBGameCore.mm
+++ b/Gambatte/GBGameCore.mm
@@ -722,6 +722,7 @@ const int GBMap[] = {gambatte::InputGetter::UP, gambatte::InputGetter::DOWN, gam
 
 - (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
 {
+    if (!gb.isLoaded()) return @[];
     const NSUInteger wramSize = 0x2000;
     NSMutableData *wramData = [NSMutableData dataWithLength:wramSize];
     uint8_t *bytes = (uint8_t *)wramData.mutableBytes;

--- a/Gambatte/Info.plist
+++ b/Gambatte/Info.plist
@@ -32,6 +32,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsDisplayModeChange</key>
 			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -26,6 +26,7 @@
 
 #import "GenPlusGameCore.h"
 #import <OpenEmuBase/OERingBuffer.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
 #import "OESMSSystemResponderClient.h"
 #import "OEGGSystemResponderClient.h"
 #import "OESG1000SystemResponderClient.h"
@@ -2136,6 +2137,26 @@ void ROMCheatUpdate(void)
 
         /* next ROM patch */
         cnt--;
+    }
+}
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+    if ((system_hw & SYSTEM_PBC) == SYSTEM_MD) {
+        NSData *data = [NSData dataWithBytes:work_ram length:0x10000];
+        OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"Work RAM"
+                                                                                  address:0xFF0000
+                                                                             addressBytes:3
+                                                                             minDataBytes:2
+                                                                                     data:data];
+        return @[descriptor];
+    } else {
+        NSData *data = [NSData dataWithBytes:work_ram length:0x2000];
+        OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"RAM"
+                                                                                  address:0xC000
+                                                                             addressBytes:2
+                                                                                     data:data];
+        return @[descriptor];
     }
 }
 

--- a/GenesisPlus/GenPlusGameCore.m
+++ b/GenesisPlus/GenPlusGameCore.m
@@ -2142,6 +2142,7 @@ void ROMCheatUpdate(void)
 
 - (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
 {
+    if (cart.romsize == 0) return @[];
     if ((system_hw & SYSTEM_PBC) == SYSTEM_MD) {
         NSData *data = [NSData dataWithBytes:work_ram length:0x10000];
         OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"Work RAM"

--- a/GenesisPlus/Info.plist
+++ b/GenesisPlus/Info.plist
@@ -34,6 +34,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsDisplayModeChange</key>
 			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>
@@ -50,6 +52,8 @@
 			<key>OEGameCoreRewindInterval</key>
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
+			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
 			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>
 			<true/>
@@ -97,6 +101,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>
 			<true/>
 			<key>OEGameCoreSupportsRewinding</key>
@@ -110,6 +116,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>
 			<true/>
 			<key>OEGameCoreSupportsRewinding</key>
@@ -122,6 +130,8 @@
 			<key>OEGameCoreRewindInterval</key>
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
+			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
 			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>
 			<true/>

--- a/Mednafen/Info.plist
+++ b/Mednafen/Info.plist
@@ -120,6 +120,8 @@
 			<true/>
 			<key>OEGameCoreSupportsMultipleDiscs</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatCode</key>
+			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>
 			<true/>
 			<key>OERequiredFiles</key>

--- a/Mednafen/Info.plist
+++ b/Mednafen/Info.plist
@@ -122,6 +122,8 @@
 			<true/>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>
 			<true/>
 			<key>OERequiredFiles</key>

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -32,6 +32,7 @@
 #include "MemoryStream.h"
 #include "mednafen/psx/psx.h"
 #include "mednafen/pce/pce.h"
+#include "mednafen/mempatcher-driver.h"
 
 #import "MednafenGameCore.h"
 #import <OpenEmuBase/OERingBuffer.h>
@@ -4246,6 +4247,49 @@ const int WSMap[]   = { 0, 2, 3, 1, 4, 6, 7, 5, 9, 10, 8, 11 };
 
     _mouseScaledX = aPoint.x * (CGFloat)scaledRatio.width;
     _mouseScaledY = aPoint.y * (CGFloat)scaledRatio.height;
+}
+
+#pragma mark - Cheats
+
+- (void)setCheat:(NSString *)code setType:(NSString *)type setEnabled:(BOOL)enabled
+{
+    code = [code stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    code = [code stringByReplacingOccurrencesOfString:@" " withString:@""];
+
+    Mednafen::MemoryPatch patch;
+    patch.status = enabled;
+    patch.type = 'R';
+    patch.bigendian = false;
+
+    NSArray<NSString *> *codes = [code componentsSeparatedByString:@"+"];
+    for (NSString *singleCode in codes) {
+        NSRange colonRange = [singleCode rangeOfString:@":"];
+        if (colonRange.location != NSNotFound) {
+            // Raw format: ADDR:VALUE
+            unsigned int addr = 0, val = 0;
+            [[NSScanner scannerWithString:[singleCode substringToIndex:colonRange.location]] scanHexInt:&addr];
+            [[NSScanner scannerWithString:[singleCode substringFromIndex:colonRange.location + 1]] scanHexInt:&val];
+            patch.addr = addr;
+            patch.val = val;
+            patch.length = 1;
+            Mednafen::MDFNI_AddCheat(patch);
+        } else if (singleCode.length == 12) {
+            // PSX GameShark: TTAAAAAAVVVV (decoded by Mednafen's CheatFormats)
+            unsigned long long raw = strtoull(singleCode.UTF8String, NULL, 16);
+            uint8_t codeType = (raw >> 40) & 0xFF;
+            uint32_t addr = (raw >> 16) & 0xFFFFFF;
+            uint16_t val = raw & 0xFFFF;
+            patch.addr = addr;
+            if (codeType == 0x30) {
+                patch.val = val & 0xFF;
+                patch.length = 1;
+            } else {
+                patch.val = val;
+                patch.length = 2;
+            }
+            Mednafen::MDFNI_AddCheat(patch);
+        }
+    }
 }
 
 @end

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -37,6 +37,7 @@
 #import "MednafenGameCore.h"
 #import <OpenEmuBase/OERingBuffer.h>
 #import <OpenEmuBase/OEGameCoreDisplayModes.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
 #import <OpenGL/gl.h>
 #import "OELynxSystemResponderClient.h"
 #import "OENGPSystemResponderClient.h"
@@ -4290,6 +4291,18 @@ const int WSMap[]   = { 0, 2, 3, 1, 4, 6, 7, 5, 9, 10, 8, 11 };
             Mednafen::MDFNI_AddCheat(patch);
         }
     }
+}
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+    if ([_mednafenCoreModule isEqualToString:@"psx"]) {
+        NSData *data = [NSData dataWithBytes:MDFN_IEN_PSX::MainRAM.data8 length:2 * 1024 * 1024];
+        return @[[OEMemoryRegionDescriptor descriptorWithName:@"Main RAM"
+                                                     address:0x80000000
+                                                addressBytes:4
+                                                        data:data]];
+    }
+    return @[];
 }
 
 @end

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -4282,8 +4282,8 @@ namespace Mednafen { void MDFN_FlushGameCheats(int nosave); }
             NSRange colonRange = [singleCode rangeOfString:@":"];
             if (colonRange.location != NSNotFound) {
                 unsigned int addr = 0, val = 0;
-                [[NSScanner scannerWithString:[singleCode substringToIndex:colonRange.location]] scanHexInt:&addr];
-                [[NSScanner scannerWithString:[singleCode substringFromIndex:colonRange.location + 1]] scanHexInt:&val];
+                if (![[NSScanner scannerWithString:[singleCode substringToIndex:colonRange.location]] scanHexInt:&addr]) continue;
+                if (![[NSScanner scannerWithString:[singleCode substringFromIndex:colonRange.location + 1]] scanHexInt:&val]) continue;
                 patch.addr = addr;
                 patch.val = val;
                 patch.length = 1;

--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -113,6 +113,7 @@ namespace MDFN_IEN_VB
     OERetroAchievementsBridge *_raBridge;
     NSString *_romPath;
     int _rcConsole;
+    NSMutableDictionary<NSString *, NSNumber *> *_cheatList;
     BOOL _isSystemPCECD;
     // Owned C-string copy of the active console module name (e.g. "psx", "pce").
     // Read from the RA memory-reader trampoline on the bridge's serial queue
@@ -4252,43 +4253,56 @@ const int WSMap[]   = { 0, 2, 3, 1, 4, 6, 7, 5, 9, 10, 8, 11 };
 
 #pragma mark - Cheats
 
+namespace Mednafen { void MDFN_FlushGameCheats(int nosave); }
+
 - (void)setCheat:(NSString *)code setType:(NSString *)type setEnabled:(BOOL)enabled
 {
     code = [code stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     code = [code stringByReplacingOccurrencesOfString:@" " withString:@""];
 
-    Mednafen::MemoryPatch patch;
-    patch.status = enabled;
-    patch.type = 'R';
-    patch.bigendian = false;
+    if (!_cheatList)
+        _cheatList = [NSMutableDictionary dictionary];
 
-    NSArray<NSString *> *codes = [code componentsSeparatedByString:@"+"];
-    for (NSString *singleCode in codes) {
-        NSRange colonRange = [singleCode rangeOfString:@":"];
-        if (colonRange.location != NSNotFound) {
-            // Raw format: ADDR:VALUE
-            unsigned int addr = 0, val = 0;
-            [[NSScanner scannerWithString:[singleCode substringToIndex:colonRange.location]] scanHexInt:&addr];
-            [[NSScanner scannerWithString:[singleCode substringFromIndex:colonRange.location + 1]] scanHexInt:&val];
-            patch.addr = addr;
-            patch.val = val;
-            patch.length = 1;
-            Mednafen::MDFNI_AddCheat(patch);
-        } else if (singleCode.length == 12) {
-            // PSX GameShark: TTAAAAAAVVVV (decoded by Mednafen's CheatFormats)
-            unsigned long long raw = strtoull(singleCode.UTF8String, NULL, 16);
-            uint8_t codeType = (raw >> 40) & 0xFF;
-            uint32_t addr = (raw >> 16) & 0xFFFFFF;
-            uint16_t val = raw & 0xFFFF;
-            patch.addr = addr;
-            if (codeType == 0x30) {
-                patch.val = val & 0xFF;
-                patch.length = 1;
-            } else {
+    if (enabled)
+        _cheatList[code] = @YES;
+    else
+        [_cheatList removeObjectForKey:code];
+
+    Mednafen::MDFN_FlushGameCheats(1);
+
+    for (NSString *key in _cheatList) {
+        if (![_cheatList[key] boolValue]) continue;
+        NSArray<NSString *> *parts = [key componentsSeparatedByString:@"+"];
+        for (NSString *singleCode in parts) {
+            Mednafen::MemoryPatch patch;
+            patch.status = true;
+            patch.type = 'R';
+            patch.bigendian = false;
+
+            NSRange colonRange = [singleCode rangeOfString:@":"];
+            if (colonRange.location != NSNotFound) {
+                unsigned int addr = 0, val = 0;
+                [[NSScanner scannerWithString:[singleCode substringToIndex:colonRange.location]] scanHexInt:&addr];
+                [[NSScanner scannerWithString:[singleCode substringFromIndex:colonRange.location + 1]] scanHexInt:&val];
+                patch.addr = addr;
                 patch.val = val;
-                patch.length = 2;
+                patch.length = 1;
+                Mednafen::MDFNI_AddCheat(patch);
+            } else if (singleCode.length == 12) {
+                unsigned long long raw = strtoull(singleCode.UTF8String, NULL, 16);
+                uint8_t codeType = (raw >> 40) & 0xFF;
+                uint32_t addr = (raw >> 16) & 0xFFFFFF;
+                uint16_t val = raw & 0xFFFF;
+                patch.addr = addr;
+                if (codeType == 0x30) {
+                    patch.val = val & 0xFF;
+                    patch.length = 1;
+                } else {
+                    patch.val = val;
+                    patch.length = 2;
+                }
+                Mednafen::MDFNI_AddCheat(patch);
             }
-            Mednafen::MDFNI_AddCheat(patch);
         }
     }
 }

--- a/Mupen64Plus/Info.plist
+++ b/Mupen64Plus/Info.plist
@@ -34,6 +34,8 @@
 			<true/>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>
 			<true/>
 		</dict>

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -1072,7 +1072,6 @@ static void MupenSetAudioSpeed(int percent)
     OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"RDRAM"
                                                                               address:0x80000000
                                                                          addressBytes:4
-                                                                         minDataBytes:2
                                                                                  data:data];
     return @[descriptor];
 }

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -30,6 +30,7 @@
 #import "MupenGameCore.h"
 #import <OpenEmuBase/OERingBuffer.h>
 #import <OpenEmuBase/OETimingUtils.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
 #import "OEN64SystemResponderClient.h"
 #import <OpenGL/gl.h>
 
@@ -1061,6 +1062,17 @@ static void MupenSetAudioSpeed(int percent)
     }
 
     free(gsCode);
+}
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+    uint32_t dramSize = (uint32_t)g_dev.rdram.dram_size;
+    NSData *data = [NSData dataWithBytes:g_dev.rdram.dram length:dramSize];
+    OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"RDRAM"
+                                                                              address:0x80000000
+                                                                         addressBytes:4
+                                                                                 data:data];
+    return @[descriptor];
 }
 
 @end

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -1035,8 +1035,8 @@ static void MupenSetAudioSpeed(int percent)
             unsigned int outAddress, outValue;
             NSScanner *scanAddress = [NSScanner scannerWithString:address];
             NSScanner *scanValue = [NSScanner scannerWithString:value];
-            [scanAddress scanHexInt:&outAddress];
-            [scanValue scanHexInt:&outValue];
+            if (![scanAddress scanHexInt:&outAddress] || ![scanValue scanHexInt:&outValue])
+                continue;
             
             gsCode[codeCounter].address = outAddress;
             gsCode[codeCounter].value = outValue;

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -1066,6 +1066,7 @@ static void MupenSetAudioSpeed(int percent)
 
 - (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
 {
+    if (!g_dev.rdram.dram) return @[];
     uint32_t dramSize = (uint32_t)g_dev.rdram.dram_size;
     NSData *data = [NSData dataWithBytes:g_dev.rdram.dram length:dramSize];
     OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"RDRAM"

--- a/Mupen64Plus/MupenGameCore.m
+++ b/Mupen64Plus/MupenGameCore.m
@@ -1072,6 +1072,7 @@ static void MupenSetAudioSpeed(int percent)
     OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"RDRAM"
                                                                               address:0x80000000
                                                                          addressBytes:4
+                                                                         minDataBytes:2
                                                                                  data:data];
     return @[descriptor];
 }

--- a/Nestopia/Info.plist
+++ b/Nestopia/Info.plist
@@ -36,6 +36,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsDisplayModeChange</key>
 			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>
@@ -63,6 +65,8 @@
 			<key>OEGameCoreRewindInterval</key>
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
+			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
 			<true/>
 			<key>OEGameCoreSupportsDisplayModeChange</key>
 			<true/>

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -27,6 +27,7 @@
 
 #import "NESGameCore.h"
 #import <OpenEmuBase/OERingBuffer.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
 #import "OENESSystemResponderClient.h"
 #import "OEFDSSystemResponderClient.h"
 #import <OpenGL/gl.h>
@@ -1132,6 +1133,18 @@ void NST_CALLBACK doEvent(void *userData, Nes::Api::Machine::Event event, Nes::R
         case Nes::Api::Machine::EVENT_MODE_PAL :
             break;
     }
+}
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+    Nes::Api::Cheats cheater(_emu);
+    Nes::Api::Cheats::Ram ram = cheater.GetRam();
+    NSData *data = [NSData dataWithBytes:ram length:0x800];
+    OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"RAM"
+                                                                              address:0x0000
+                                                                         addressBytes:2
+                                                                                 data:data];
+    return @[descriptor];
 }
 
 @end

--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -1139,6 +1139,7 @@ void NST_CALLBACK doEvent(void *userData, Nes::Api::Machine::Event event, Nes::R
 {
     Nes::Api::Cheats cheater(_emu);
     Nes::Api::Cheats::Ram ram = cheater.GetRam();
+    if (!ram) return @[];
     NSData *data = [NSData dataWithBytes:ram length:0x800];
     OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"RAM"
                                                                               address:0x0000

--- a/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
+++ b/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		05FF41B922B08C5F00BB7283 /* OELogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 05FF41B722B08C5F00BB7283 /* OELogging.h */; };
 		27FC95181A92F12700CF1DC6 /* OEDiffQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 27FC95161A92F12700CF1DC6 /* OEDiffQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27FC95191A92F12700CF1DC6 /* OEDiffQueue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27FC95171A92F12700CF1DC6 /* OEDiffQueue.mm */; };
+		5E427923D438B2BBDCB457B9 /* OESystemConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E2F988CC2D67CFDA1EC461B /* OESystemConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63D108D227B98A7A6A343F72 /* OEMemoryRegionDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = E3726762F8CB752642F1B71C /* OEMemoryRegionDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8363A434193CA52400F18425 /* OEGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 8363A433193CA52400F18425 /* OEGeometry.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		878203EA21C4A09900C1C2C9 /* OEDreamcastGDI.h in Headers */ = {isa = PBXBuildFile; fileRef = 878203E821C4A09800C1C2C9 /* OEDreamcastGDI.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -44,6 +45,7 @@
 		94FDE6AF1AC35BA60003D247 /* OECloneCD.m in Sources */ = {isa = PBXBuildFile; fileRef = 94FDE6AD1AC35BA60003D247 /* OECloneCD.m */; };
 		B5AE7A121710BD6200ED5801 /* OELibretroCoreTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = B5AE7A111710BD6200ED5801 /* OELibretroCoreTranslator.m */; };
 		B5AE7A141710BD6200ED5801 /* OELibretroCoreTranslator.h in Headers */ = {isa = PBXBuildFile; fileRef = B5AE7A131710BD6200ED5801 /* OELibretroCoreTranslator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B8296619452A248C4B234493 /* OESystemConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = DCAFB56D006087C1FE9C74D0 /* OESystemConstants.m */; };
 		C6206C0E1C08EB80008E0106 /* OEBindingDescription_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = C6206C0D1C08EB80008E0106 /* OEBindingDescription_Internal.h */; };
 		C6605B841D725B0D009C7E91 /* OEM3UFile.h in Headers */ = {isa = PBXBuildFile; fileRef = C6605B821D725B0D009C7E91 /* OEM3UFile.h */; };
 		C6605B851D725B0D009C7E91 /* OEM3UFile.m in Sources */ = {isa = PBXBuildFile; fileRef = C6605B831D725B0D009C7E91 /* OEM3UFile.m */; };
@@ -173,6 +175,7 @@
 		05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSDataCategoryTests.m; sourceTree = "<group>"; };
 		05FF41B622B08C5F00BB7283 /* OELogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OELogging.m; sourceTree = "<group>"; };
 		05FF41B722B08C5F00BB7283 /* OELogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OELogging.h; sourceTree = "<group>"; };
+		1E2F988CC2D67CFDA1EC461B /* OESystemConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = OESystemConstants.h; sourceTree = "<group>"; };
 		27FC95161A92F12700CF1DC6 /* OEDiffQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEDiffQueue.h; sourceTree = "<group>"; };
 		27FC95171A92F12700CF1DC6 /* OEDiffQueue.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OEDiffQueue.mm; sourceTree = "<group>"; };
 		649A876CCFF99B047EEF024C /* OEMemoryRegionDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = OEMemoryRegionDescriptor.m; sourceTree = "<group>"; };
@@ -269,6 +272,7 @@
 		C6A726821C059BF000E35961 /* OEBindingDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEBindingDescription.m; sourceTree = "<group>"; };
 		C6F16C4A1D73582C008E0C57 /* OEFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEFile.h; sourceTree = "<group>"; };
 		C6F16C4B1D73582C008E0C57 /* OEFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEFile.m; sourceTree = "<group>"; };
+		DCAFB56D006087C1FE9C74D0 /* OESystemConstants.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = OESystemConstants.m; sourceTree = "<group>"; };
 		E3726762F8CB752642F1B71C /* OEMemoryRegionDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = OEMemoryRegionDescriptor.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -397,6 +401,8 @@
 				011FAED32325B8F900DBEC62 /* NSDictionary+OpenEmuSDK.m */,
 				E3726762F8CB752642F1B71C /* OEMemoryRegionDescriptor.h */,
 				649A876CCFF99B047EEF024C /* OEMemoryRegionDescriptor.m */,
+				1E2F988CC2D67CFDA1EC461B /* OESystemConstants.h */,
+				DCAFB56D006087C1FE9C74D0 /* OESystemConstants.m */,
 			);
 			path = OpenEmuBase;
 			sourceTree = "<group>";
@@ -566,6 +572,7 @@
 				05FF41B922B08C5F00BB7283 /* OELogging.h in Headers */,
 				013D75CD23BD25CB00D74AD3 /* OEGameCoreDisplayModes.h in Headers */,
 				63D108D227B98A7A6A343F72 /* OEMemoryRegionDescriptor.h in Headers */,
+				5E427923D438B2BBDCB457B9 /* OESystemConstants.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -805,6 +812,7 @@
 				0572A3FF287781BA00AC32F8 /* OEGeometry.swift in Sources */,
 				0442B0021A2F4E6C00442002 /* HardcoreModePolicy.swift in Sources */,
 				CE117DFAA143768BB64EA609 /* OEMemoryRegionDescriptor.m in Sources */,
+				B8296619452A248C4B234493 /* OESystemConstants.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
+++ b/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
@@ -7,10 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B5AE7A121710BD6200ED5801 /* OELibretroCoreTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = B5AE7A111710BD6200ED5801 /* OELibretroCoreTranslator.m */; };
-		B5AE7A141710BD6200ED5801 /* OELibretroCoreTranslator.h in Headers */ = {isa = PBXBuildFile; fileRef = B5AE7A131710BD6200ED5801 /* OELibretroCoreTranslator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0109BBA5209F25EB002419C1 /* OEDiffQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0109BBA4209F25EB002419C1 /* OEDiffQueueTests.m */; };
-		0442B0011A2F4E6C00442001 /* OEGameCoreHardcoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0442B0001A2F4E6C00442001 /* OEGameCoreHardcoreTests.m */; };
 		0109BBA7209F25EB002419C1 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6772A261710A4BA00ED580A /* OpenEmuBase.framework */; };
 		011829A720ACA8AA0030B347 /* OEAudioBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 011829A620ACA8AA0030B347 /* OEAudioBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		011FAED42325B8F900DBEC62 /* NSDictionary+OpenEmuSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 011FAED22325B8F900DBEC62 /* NSDictionary+OpenEmuSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -24,10 +21,11 @@
 		01C0F4372327184F00311409 /* OEDeviceManager_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 01C0F436232717C700311409 /* OEDeviceManager_Internal.h */; };
 		01F306FB20AA1C64005C8F18 /* NSUserDefaults+OpenEmuSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 01F306F920AA1C64005C8F18 /* NSUserDefaults+OpenEmuSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		01F306FC20AA1C64005C8F18 /* NSUserDefaults+OpenEmuSDK.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F306FA20AA1C64005C8F18 /* NSUserDefaults+OpenEmuSDK.m */; };
-		0518D6DD24F17C6E0037101D /* OEGeometry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0518D6DC24F17C6E0037101D /* OEGeometry.m */; };
-		0572A3FF287781BA00AC32F8 /* OEGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0572A3FE287781BA00AC32F8 /* OEGeometry.swift */; };
+		0442B0011A2F4E6C00442001 /* OEGameCoreHardcoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0442B0001A2F4E6C00442001 /* OEGameCoreHardcoreTests.m */; };
 		0442B0021A2F4E6C00442002 /* HardcoreModePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0442B0031A2F4E6C00442003 /* HardcoreModePolicy.swift */; };
 		0442B0041A2F4E6C00442004 /* HardcoreModePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0442B0051A2F4E6C00442005 /* HardcoreModePolicyTests.swift */; };
+		0518D6DD24F17C6E0037101D /* OEGeometry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0518D6DC24F17C6E0037101D /* OEGeometry.m */; };
+		0572A3FF287781BA00AC32F8 /* OEGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0572A3FE287781BA00AC32F8 /* OEGeometry.swift */; };
 		05F2F90824EA029900BFAF18 /* Controller-Database.plist in Resources */ = {isa = PBXBuildFile; fileRef = 05F2F90724EA029900BFAF18 /* Controller-Database.plist */; };
 		05FC85B1295E49FE003DED0C /* NSDataCategoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */; };
 		05FC85B2295E49FE003DED0C /* OpenEmuSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6772A8C1710CD7E00ED580A /* OpenEmuSystem.framework */; };
@@ -35,6 +33,7 @@
 		05FF41B922B08C5F00BB7283 /* OELogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 05FF41B722B08C5F00BB7283 /* OELogging.h */; };
 		27FC95181A92F12700CF1DC6 /* OEDiffQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 27FC95161A92F12700CF1DC6 /* OEDiffQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27FC95191A92F12700CF1DC6 /* OEDiffQueue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27FC95171A92F12700CF1DC6 /* OEDiffQueue.mm */; };
+		63D108D227B98A7A6A343F72 /* OEMemoryRegionDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = E3726762F8CB752642F1B71C /* OEMemoryRegionDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8363A434193CA52400F18425 /* OEGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 8363A433193CA52400F18425 /* OEGeometry.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		878203EA21C4A09900C1C2C9 /* OEDreamcastGDI.h in Headers */ = {isa = PBXBuildFile; fileRef = 878203E821C4A09800C1C2C9 /* OEDreamcastGDI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		878203EB21C4A09900C1C2C9 /* OEDreamcastGDI.m in Sources */ = {isa = PBXBuildFile; fileRef = 878203E921C4A09800C1C2C9 /* OEDreamcastGDI.m */; };
@@ -43,6 +42,8 @@
 		8F7909962A1A07C200E98FE8 /* OpenEmuSystemPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F7909932A1A07C200E98FE8 /* OpenEmuSystemPrivate.h */; };
 		94FDE6AE1AC35BA60003D247 /* OECloneCD.h in Headers */ = {isa = PBXBuildFile; fileRef = 94FDE6AC1AC35BA60003D247 /* OECloneCD.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		94FDE6AF1AC35BA60003D247 /* OECloneCD.m in Sources */ = {isa = PBXBuildFile; fileRef = 94FDE6AD1AC35BA60003D247 /* OECloneCD.m */; };
+		B5AE7A121710BD6200ED5801 /* OELibretroCoreTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = B5AE7A111710BD6200ED5801 /* OELibretroCoreTranslator.m */; };
+		B5AE7A141710BD6200ED5801 /* OELibretroCoreTranslator.h in Headers */ = {isa = PBXBuildFile; fileRef = B5AE7A131710BD6200ED5801 /* OELibretroCoreTranslator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C6206C0E1C08EB80008E0106 /* OEBindingDescription_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = C6206C0D1C08EB80008E0106 /* OEBindingDescription_Internal.h */; };
 		C6605B841D725B0D009C7E91 /* OEM3UFile.h in Headers */ = {isa = PBXBuildFile; fileRef = C6605B821D725B0D009C7E91 /* OEM3UFile.h */; };
 		C6605B851D725B0D009C7E91 /* OEM3UFile.m in Sources */ = {isa = PBXBuildFile; fileRef = C6605B831D725B0D009C7E91 /* OEM3UFile.m */; };
@@ -120,6 +121,7 @@
 		C6A726841C059BF000E35961 /* OEBindingDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = C6A726821C059BF000E35961 /* OEBindingDescription.m */; };
 		C6F16C4C1D73582C008E0C57 /* OEFile.h in Headers */ = {isa = PBXBuildFile; fileRef = C6F16C4A1D73582C008E0C57 /* OEFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C6F16C4D1D73582C008E0C57 /* OEFile.m in Sources */ = {isa = PBXBuildFile; fileRef = C6F16C4B1D73582C008E0C57 /* OEFile.m */; };
+		CE117DFAA143768BB64EA609 /* OEMemoryRegionDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 649A876CCFF99B047EEF024C /* OEMemoryRegionDescriptor.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -147,12 +149,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		B5AE7A111710BD6200ED5801 /* OELibretroCoreTranslator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OELibretroCoreTranslator.m; sourceTree = "<group>"; };
-		B5AE7A131710BD6200ED5801 /* OELibretroCoreTranslator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OELibretroCoreTranslator.h; sourceTree = "<group>"; };
-		B5AE7A151710BD6200ED5801 /* libretro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libretro.h; sourceTree = "<group>"; };
 		0109BBA2209F25EB002419C1 /* OpenEmuBaseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenEmuBaseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0109BBA4209F25EB002419C1 /* OEDiffQueueTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OEDiffQueueTests.m; sourceTree = "<group>"; };
-		0442B0001A2F4E6C00442001 /* OEGameCoreHardcoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OEGameCoreHardcoreTests.m; sourceTree = "<group>"; };
 		011829A620ACA8AA0030B347 /* OEAudioBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OEAudioBuffer.h; sourceTree = "<group>"; };
 		011FAED22325B8F900DBEC62 /* NSDictionary+OpenEmuSDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+OpenEmuSDK.h"; sourceTree = "<group>"; };
 		011FAED32325B8F900DBEC62 /* NSDictionary+OpenEmuSDK.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+OpenEmuSDK.m"; sourceTree = "<group>"; };
@@ -165,10 +163,11 @@
 		01C0F436232717C700311409 /* OEDeviceManager_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OEDeviceManager_Internal.h; sourceTree = "<group>"; };
 		01F306F920AA1C64005C8F18 /* NSUserDefaults+OpenEmuSDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSUserDefaults+OpenEmuSDK.h"; sourceTree = "<group>"; };
 		01F306FA20AA1C64005C8F18 /* NSUserDefaults+OpenEmuSDK.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSUserDefaults+OpenEmuSDK.m"; sourceTree = "<group>"; };
-		0518D6DC24F17C6E0037101D /* OEGeometry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OEGeometry.m; sourceTree = "<group>"; };
-		0572A3FE287781BA00AC32F8 /* OEGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OEGeometry.swift; sourceTree = "<group>"; };
+		0442B0001A2F4E6C00442001 /* OEGameCoreHardcoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OEGameCoreHardcoreTests.m; sourceTree = "<group>"; };
 		0442B0031A2F4E6C00442003 /* HardcoreModePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardcoreModePolicy.swift; sourceTree = "<group>"; };
 		0442B0051A2F4E6C00442005 /* HardcoreModePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardcoreModePolicyTests.swift; sourceTree = "<group>"; };
+		0518D6DC24F17C6E0037101D /* OEGeometry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OEGeometry.m; sourceTree = "<group>"; };
+		0572A3FE287781BA00AC32F8 /* OEGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OEGeometry.swift; sourceTree = "<group>"; };
 		05F2F90724EA029900BFAF18 /* Controller-Database.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Controller-Database.plist"; sourceTree = "<group>"; };
 		05FC85AE295E49FE003DED0C /* OpenEmuSystemTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenEmuSystemTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSDataCategoryTests.m; sourceTree = "<group>"; };
@@ -176,6 +175,7 @@
 		05FF41B722B08C5F00BB7283 /* OELogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OELogging.h; sourceTree = "<group>"; };
 		27FC95161A92F12700CF1DC6 /* OEDiffQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEDiffQueue.h; sourceTree = "<group>"; };
 		27FC95171A92F12700CF1DC6 /* OEDiffQueue.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OEDiffQueue.mm; sourceTree = "<group>"; };
+		649A876CCFF99B047EEF024C /* OEMemoryRegionDescriptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = OEMemoryRegionDescriptor.m; sourceTree = "<group>"; };
 		8363A433193CA52400F18425 /* OEGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEGeometry.h; sourceTree = "<group>"; };
 		878203E821C4A09800C1C2C9 /* OEDreamcastGDI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEDreamcastGDI.h; sourceTree = "<group>"; };
 		878203E921C4A09800C1C2C9 /* OEDreamcastGDI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEDreamcastGDI.m; sourceTree = "<group>"; };
@@ -186,6 +186,9 @@
 		8F7909952A1A07C200E98FE8 /* OpenEmuSystem.private.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = OpenEmuSystem.private.modulemap; path = OpenEmuSystem/OpenEmuSystem.private.modulemap; sourceTree = SOURCE_ROOT; };
 		94FDE6AC1AC35BA60003D247 /* OECloneCD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OECloneCD.h; sourceTree = "<group>"; };
 		94FDE6AD1AC35BA60003D247 /* OECloneCD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OECloneCD.m; sourceTree = "<group>"; };
+		B5AE7A111710BD6200ED5801 /* OELibretroCoreTranslator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OELibretroCoreTranslator.m; sourceTree = "<group>"; };
+		B5AE7A131710BD6200ED5801 /* OELibretroCoreTranslator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OELibretroCoreTranslator.h; sourceTree = "<group>"; };
+		B5AE7A151710BD6200ED5801 /* libretro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libretro.h; sourceTree = "<group>"; };
 		C6206C0D1C08EB80008E0106 /* OEBindingDescription_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEBindingDescription_Internal.h; sourceTree = "<group>"; };
 		C6605B821D725B0D009C7E91 /* OEM3UFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEM3UFile.h; sourceTree = "<group>"; };
 		C6605B831D725B0D009C7E91 /* OEM3UFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEM3UFile.m; sourceTree = "<group>"; };
@@ -266,6 +269,7 @@
 		C6A726821C059BF000E35961 /* OEBindingDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEBindingDescription.m; sourceTree = "<group>"; };
 		C6F16C4A1D73582C008E0C57 /* OEFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEFile.h; sourceTree = "<group>"; };
 		C6F16C4B1D73582C008E0C57 /* OEFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEFile.m; sourceTree = "<group>"; };
+		E3726762F8CB752642F1B71C /* OEMemoryRegionDescriptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = OEMemoryRegionDescriptor.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -391,6 +395,8 @@
 				01F306FA20AA1C64005C8F18 /* NSUserDefaults+OpenEmuSDK.m */,
 				011FAED22325B8F900DBEC62 /* NSDictionary+OpenEmuSDK.h */,
 				011FAED32325B8F900DBEC62 /* NSDictionary+OpenEmuSDK.m */,
+				E3726762F8CB752642F1B71C /* OEMemoryRegionDescriptor.h */,
+				649A876CCFF99B047EEF024C /* OEMemoryRegionDescriptor.m */,
 			);
 			path = OpenEmuBase;
 			sourceTree = "<group>";
@@ -559,6 +565,7 @@
 				C6772A7A1710BD6200ED580A /* OETimingUtils.h in Headers */,
 				05FF41B922B08C5F00BB7283 /* OELogging.h in Headers */,
 				013D75CD23BD25CB00D74AD3 /* OEGameCoreDisplayModes.h in Headers */,
+				63D108D227B98A7A6A343F72 /* OEMemoryRegionDescriptor.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -797,6 +804,7 @@
 				0518D6DD24F17C6E0037101D /* OEGeometry.m in Sources */,
 				0572A3FF287781BA00AC32F8 /* OEGeometry.swift in Sources */,
 				0442B0021A2F4E6C00442002 /* HardcoreModePolicy.swift in Sources */,
+				CE117DFAA143768BB64EA609 /* OEMemoryRegionDescriptor.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.h
@@ -35,7 +35,7 @@
 #import <OpenEmuBase/OEDiffQueue.h>
 #import <OpenEmuBase/OEGameCoreDisplayModes.h>
 
-@class OEGameCoreController, OEGameCore;
+@class OEGameCoreController, OEGameCore, OEMemoryRegionDescriptor;
 
 /// Primary bridge input protocol — used by all system responders.
 @protocol OEBridgeInputTranslation <NSObject>
@@ -519,6 +519,12 @@ OE_EXPORTED_CLASS
 #pragma mark - Cheats - Optional
 
 - (void)setCheat:(NSString *)code setType:(NSString *)type setEnabled:(BOOL)enabled;
+
+#pragma mark - Readable Memory - Optional
+
+/// Returns an array of memory region descriptors with their current data.
+/// Override this in cores that support cheat search / memory inspection.
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions;
 
 #pragma mark - Discs - Optional
 

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCore.m
@@ -28,6 +28,7 @@
 
 #import "OEGameCore.h"
 #import "OEGameCoreController.h"
+#import "OEMemoryRegionDescriptor.h"
 #import "OEAbstractAdditions.h"
 #import "OEAudioBuffer.h"
 #import "OERingBuffer.h"
@@ -869,6 +870,11 @@ static Class GameCoreClass = Nil;
 
 - (void)setCheat:(NSString *)code setType:(NSString *)type setEnabled:(BOOL)enabled
 {
+}
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+    return @[];
 }
 
 #pragma mark - Misc

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCoreController.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCoreController.h
@@ -55,6 +55,7 @@ extern NSString *const OEGameCoreOptionsKey;
 
 // sub-keys of OEGameCoreOptionsKey
 extern NSString *const OEGameCoreSupportsCheatCodeKey;
+extern NSString *const OEGameCoreSupportsCheatSearchKey;
 extern NSString *const OEGameCoreRequiresFilesKey;
 extern NSString *const OEGameCoreRequiredFilesKey;
 extern NSString *const OEGameCoreHasGlitchesKey;

--- a/OpenEmu-SDK/OpenEmuBase/OEGameCoreController.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEGameCoreController.m
@@ -44,6 +44,7 @@ NSString *const OEGameCoreOptionsKey           = @"OEGameCoreOptions";
 
 // sub-keys of OEGameCoreOptionsKey
 NSString *const OEGameCoreSupportsCheatCodeKey = @"OEGameCoreSupportsCheatCode";
+NSString *const OEGameCoreSupportsCheatSearchKey = @"OEGameCoreSupportsCheatSearch";
 NSString *const OEGameCoreRequiresFilesKey     = @"OEGameCoreRequiresFiles";
 NSString *const OEGameCoreHasGlitchesKey       = @"OEGameCoreHasGlitches";
 NSString *const OEGameCoreSupportsMultipleDiscsKey = @"OEGameCoreSupportsMultipleDiscs";

--- a/OpenEmu-SDK/OpenEmuBase/OEMemoryRegionDescriptor.h
+++ b/OpenEmu-SDK/OpenEmuBase/OEMemoryRegionDescriptor.h
@@ -1,0 +1,63 @@
+/*
+ Copyright (c) 2026, OpenEmu Team
+ Author: Leonardo Kasperavičius
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+     * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+     * Neither the name of the OpenEmu Team nor the
+       names of its contributors may be used to endorse or promote products
+       derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Describes a contiguous region of readable memory exposed by a game core.
+@interface OEMemoryRegionDescriptor : NSObject
+
+/// A short human-readable label for this region (e.g. "EWRAM", "IWRAM").
+@property (nonatomic, readonly, copy) NSString *name;
+
+/// The base address of this region in the console's address space.
+@property (nonatomic, readonly) uint32_t address;
+
+/// The number of bytes used to represent addresses in this system's address space.
+/// For example: 1 for Atari 2600 (8-bit), 2 for NES (16-bit), 3 for SNES (24-bit), 4 for GBA (32-bit).
+@property (nonatomic, readonly) uint8_t addressBytes;
+
+/// The raw bytes of this memory region. The length of this data is the region's size in bytes.
+@property (nonatomic, readonly, copy) NSData *data;
+
+/// The minimum number of bytes per data unit for this system's cheat format.
+/// For byte-addressable systems (NES, SNES, GB, GBA, SMS, etc.) this is 1 (default).
+/// For word-addressed systems (Genesis/Mega Drive) this is 2.
+@property (nonatomic, readonly) uint8_t minDataBytes;
+
+- (instancetype)initWithName:(NSString *)name address:(uint32_t)address addressBytes:(uint8_t)addressBytes minDataBytes:(uint8_t)minDataBytes data:(NSData *)data;
++ (instancetype)descriptorWithName:(NSString *)name address:(uint32_t)address addressBytes:(uint8_t)addressBytes minDataBytes:(uint8_t)minDataBytes data:(NSData *)data;
+
+- (instancetype)initWithName:(NSString *)name address:(uint32_t)address addressBytes:(uint8_t)addressBytes data:(NSData *)data;
++ (instancetype)descriptorWithName:(NSString *)name address:(uint32_t)address addressBytes:(uint8_t)addressBytes data:(NSData *)data;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OpenEmu-SDK/OpenEmuBase/OEMemoryRegionDescriptor.m
+++ b/OpenEmu-SDK/OpenEmuBase/OEMemoryRegionDescriptor.m
@@ -1,5 +1,6 @@
 /*
- Copyright (c) 2011, OpenEmu Team
+ Copyright (c) 2026, OpenEmu Team
+ Author: Leonardo Kasperavičius
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
@@ -24,26 +25,35 @@
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <Foundation/Foundation.h>
-#if TARGET_OS_OSX
-#import <Cocoa/Cocoa.h>
-#endif
+#import "OEMemoryRegionDescriptor.h"
 
-#if !__has_feature(objc_arc)
-#error OEGameCores will probably not function without ARC
-#endif
+@implementation OEMemoryRegionDescriptor
 
-#import <OpenEmuBase/NSDictionary+OpenEmuSDK.h>
-#import <OpenEmuBase/OEAbstractAdditions.h>
-#import <OpenEmuBase/OEGameCore.h>
-#import <OpenEmuBase/OELibretroCoreTranslator.h>
-#import <OpenEmuBase/OEGameCoreController.h>
-#import <OpenEmuBase/OERingBuffer.h>
-#import <OpenEmuBase/OESystemResponderClient.h>
-#import <OpenEmuBase/OETimingUtils.h>
-#import <OpenEmuBase/TPCircularBuffer.h>
-#import <OpenEmuBase/OEAudioBuffer.h>
-#import <OpenEmuBase/NSUserDefaults+OpenEmuSDK.h>
-#import <OpenEmuBase/OEGameCoreDisplayModes.h>
-#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
-#import <OpenEmuBase/OELibretroCoreTranslator.h>
+- (instancetype)initWithName:(NSString *)name address:(uint32_t)address addressBytes:(uint8_t)addressBytes minDataBytes:(uint8_t)minDataBytes data:(NSData *)data
+{
+    if ((self = [super init])) {
+        _name = [name copy];
+        _address = address;
+        _addressBytes = addressBytes;
+        _minDataBytes = minDataBytes;
+        _data = [data copy];
+    }
+    return self;
+}
+
++ (instancetype)descriptorWithName:(NSString *)name address:(uint32_t)address addressBytes:(uint8_t)addressBytes minDataBytes:(uint8_t)minDataBytes data:(NSData *)data
+{
+    return [[self alloc] initWithName:name address:address addressBytes:addressBytes minDataBytes:minDataBytes data:data];
+}
+
+- (instancetype)initWithName:(NSString *)name address:(uint32_t)address addressBytes:(uint8_t)addressBytes data:(NSData *)data
+{
+    return [self initWithName:name address:address addressBytes:addressBytes minDataBytes:1 data:data];
+}
+
++ (instancetype)descriptorWithName:(NSString *)name address:(uint32_t)address addressBytes:(uint8_t)addressBytes data:(NSData *)data
+{
+    return [[self alloc] initWithName:name address:address addressBytes:addressBytes data:data];
+}
+
+@end

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
@@ -50,6 +50,7 @@ extern NSString *const OESystemIdentifierAtari2600;
 extern NSString *const OECheatTypeGameShark;
 extern NSString *const OECheatTypeActionReplay;
 extern NSString *const OECheatTypeGameGenie;
+extern NSString *const OECheatTypeRaw;
 extern NSString *const OECheatTypeUnknown;
 
 NS_ASSUME_NONNULL_END

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
@@ -1,5 +1,6 @@
 /*
- Copyright (c) 2011, OpenEmu Team
+ Copyright (c) 2026, OpenEmu Team
+ Author: Leonardo Kasperavičius
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
@@ -25,26 +26,30 @@
  */
 
 #import <Foundation/Foundation.h>
-#if TARGET_OS_OSX
-#import <Cocoa/Cocoa.h>
-#endif
 
-#if !__has_feature(objc_arc)
-#error OEGameCores will probably not function without ARC
-#endif
+NS_ASSUME_NONNULL_BEGIN
 
-#import <OpenEmuBase/NSDictionary+OpenEmuSDK.h>
-#import <OpenEmuBase/OEAbstractAdditions.h>
-#import <OpenEmuBase/OEGameCore.h>
-#import <OpenEmuBase/OELibretroCoreTranslator.h>
-#import <OpenEmuBase/OEGameCoreController.h>
-#import <OpenEmuBase/OERingBuffer.h>
-#import <OpenEmuBase/OESystemResponderClient.h>
-#import <OpenEmuBase/OETimingUtils.h>
-#import <OpenEmuBase/TPCircularBuffer.h>
-#import <OpenEmuBase/OEAudioBuffer.h>
-#import <OpenEmuBase/NSUserDefaults+OpenEmuSDK.h>
-#import <OpenEmuBase/OEGameCoreDisplayModes.h>
-#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
-#import <OpenEmuBase/OESystemConstants.h>
-#import <OpenEmuBase/OELibretroCoreTranslator.h>
+// MARK: - System Identifiers
+
+extern NSString *const OESystemIdentifierNES;
+extern NSString *const OESystemIdentifierFDS;
+extern NSString *const OESystemIdentifierSNES;
+extern NSString *const OESystemIdentifierN64;
+extern NSString *const OESystemIdentifierGB;
+extern NSString *const OESystemIdentifierGBA;
+extern NSString *const OESystemIdentifierNDS;
+extern NSString *const OESystemIdentifierGenesis;
+extern NSString *const OESystemIdentifierSMS;
+extern NSString *const OESystemIdentifierGameGear;
+extern NSString *const OESystemIdentifierSegaCD;
+extern NSString *const OESystemIdentifierSega32X;
+extern NSString *const OESystemIdentifierAtari2600;
+
+// MARK: - Cheat Code Type Strings
+
+extern NSString *const OECheatTypeGameShark;
+extern NSString *const OECheatTypeActionReplay;
+extern NSString *const OECheatTypeGameGenie;
+extern NSString *const OECheatTypeUnknown;
+
+NS_ASSUME_NONNULL_END

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
@@ -44,6 +44,7 @@ extern NSString *const OESystemIdentifierGameGear;
 extern NSString *const OESystemIdentifierSegaCD;
 extern NSString *const OESystemIdentifierSega32X;
 extern NSString *const OESystemIdentifierAtari2600;
+extern NSString *const OESystemIdentifierPSX;
 
 // MARK: - Cheat Code Type Strings
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
@@ -42,6 +42,7 @@ NSString *const OESystemIdentifierGameGear   = @"openemu.system.gg";
 NSString *const OESystemIdentifierSegaCD     = @"openemu.system.scd";
 NSString *const OESystemIdentifierSega32X    = @"openemu.system.32x";
 NSString *const OESystemIdentifierAtari2600  = @"openemu.system.2600";
+NSString *const OESystemIdentifierPSX        = @"openemu.system.psx";
 
 // MARK: - Cheat Code Type Strings
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
@@ -48,4 +48,5 @@ NSString *const OESystemIdentifierAtari2600  = @"openemu.system.2600";
 NSString *const OECheatTypeGameShark    = @"GameShark";
 NSString *const OECheatTypeActionReplay = @"Action Replay";
 NSString *const OECheatTypeGameGenie    = @"Game Genie";
+NSString *const OECheatTypeRaw          = @"Raw";
 NSString *const OECheatTypeUnknown      = @"Unknown";

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
@@ -1,5 +1,6 @@
 /*
- Copyright (c) 2011, OpenEmu Team
+ Copyright (c) 2026, OpenEmu Team
+ Author: Leonardo Kasperavičius
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
@@ -24,27 +25,27 @@
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <Foundation/Foundation.h>
-#if TARGET_OS_OSX
-#import <Cocoa/Cocoa.h>
-#endif
+#import "OESystemConstants.h"
 
-#if !__has_feature(objc_arc)
-#error OEGameCores will probably not function without ARC
-#endif
+// MARK: - System Identifiers
 
-#import <OpenEmuBase/NSDictionary+OpenEmuSDK.h>
-#import <OpenEmuBase/OEAbstractAdditions.h>
-#import <OpenEmuBase/OEGameCore.h>
-#import <OpenEmuBase/OELibretroCoreTranslator.h>
-#import <OpenEmuBase/OEGameCoreController.h>
-#import <OpenEmuBase/OERingBuffer.h>
-#import <OpenEmuBase/OESystemResponderClient.h>
-#import <OpenEmuBase/OETimingUtils.h>
-#import <OpenEmuBase/TPCircularBuffer.h>
-#import <OpenEmuBase/OEAudioBuffer.h>
-#import <OpenEmuBase/NSUserDefaults+OpenEmuSDK.h>
-#import <OpenEmuBase/OEGameCoreDisplayModes.h>
-#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
-#import <OpenEmuBase/OESystemConstants.h>
-#import <OpenEmuBase/OELibretroCoreTranslator.h>
+NSString *const OESystemIdentifierNES        = @"openemu.system.nes";
+NSString *const OESystemIdentifierFDS        = @"openemu.system.fds";
+NSString *const OESystemIdentifierSNES       = @"openemu.system.snes";
+NSString *const OESystemIdentifierN64        = @"openemu.system.n64";
+NSString *const OESystemIdentifierGB         = @"openemu.system.gb";
+NSString *const OESystemIdentifierGBA        = @"openemu.system.gba";
+NSString *const OESystemIdentifierNDS        = @"openemu.system.nds";
+NSString *const OESystemIdentifierGenesis    = @"openemu.system.sg";
+NSString *const OESystemIdentifierSMS        = @"openemu.system.sms";
+NSString *const OESystemIdentifierGameGear   = @"openemu.system.gg";
+NSString *const OESystemIdentifierSegaCD     = @"openemu.system.scd";
+NSString *const OESystemIdentifierSega32X    = @"openemu.system.32x";
+NSString *const OESystemIdentifierAtari2600  = @"openemu.system.2600";
+
+// MARK: - Cheat Code Type Strings
+
+NSString *const OECheatTypeGameShark    = @"GameShark";
+NSString *const OECheatTypeActionReplay = @"Action Replay";
+NSString *const OECheatTypeGameGenie    = @"Game Genie";
+NSString *const OECheatTypeUnknown      = @"Unknown";

--- a/OpenEmu/CheatSearchViewController.swift
+++ b/OpenEmu/CheatSearchViewController.swift
@@ -136,6 +136,21 @@ final class CheatSearchViewController: NSViewController {
     private var addCheatButton: NSButton!
     private var resultsCountLabel: NSTextField!
 
+    // MARK: - Result display cap
+    /// Maximum rows handed to the table view. Matches are kept in full in
+    /// `searchResults` so narrowing still works against every hit; only the
+    /// number of rows the table has to build is bounded.
+    ///
+    /// Without this, a broad first search (searching for 0 is common, and RAM is
+    /// full of zeroes) produces millions of rows. AppKit allocates an
+    /// accessibility element per row, which pushed the app past 5 GB and hung
+    /// the main thread in AX serialisation on N64-sized RAM.
+    ///
+    /// 1000 is set for what is actually readable rather than what is survivable.
+    /// The list is a surface you narrow down, not one you scroll to the end of,
+    /// and a realistic narrowed result set fits well inside this.
+    private static let displayLimit = 1_000
+
     override func loadView() {
         view = NSView(frame: NSRect(x: 0, y: 0, width: 620, height: 480))
     }
@@ -186,7 +201,10 @@ final class CheatSearchViewController: NSViewController {
         let dataType = defaults.integer(forKey: Self.dataTypeKey)
         selectRadio(in: dataTypeRadios, index: dataType)
 
-        let comparison = defaults.integer(forKey: Self.comparisonKey)
+        // Default to "=" rather than the first item, "<". With the other defaults
+        // (unsigned, This Value 0) a "<" search asks for an unsigned number below
+        // zero, which can never match, so a first search always came back empty.
+        let comparison = defaults.object(forKey: Self.comparisonKey) as? Int ?? Comparison.equal.rawValue
         if comparison >= 0 && comparison < comparisonCombo.numberOfItems {
             comparisonCombo.selectItem(at: comparison)
         }
@@ -209,10 +227,20 @@ final class CheatSearchViewController: NSViewController {
         updateResultsCountLabel()
     }
 
+    /// Reports the match count, and says so plainly when the table is only
+    /// showing a capped subset of them (searching for 0 is common, and RAM is
+    /// full of zeroes, so a broad first search can produce millions of hits).
     private func updateResultsCountLabel() {
         let count = searchResults.count
         if count == 0 {
             resultsCountLabel.stringValue = ""
+        } else if count > Self.displayLimit {
+            resultsCountLabel.stringValue = String(
+                format: NSLocalizedString("Showing first %1$@ of %2$@ matches, narrow your search",
+                                          comment: "Cheat Search result count when capped"),
+                NumberFormatter.localizedString(from: NSNumber(value: Self.displayLimit), number: .decimal),
+                NumberFormatter.localizedString(from: NSNumber(value: count), number: .decimal)
+            )
         } else if count == 1 {
             resultsCountLabel.stringValue = String(
                 format: NSLocalizedString("%@ result found 🎯", comment: "Cheat Search single result count"),
@@ -588,6 +616,13 @@ final class CheatSearchViewController: NSViewController {
                 self.memoryRegions = regions.sorted { $0.address < $1.address }
                 self.rebuildDataSizeCombo()
                 self.hideLoadingIndicator()
+                // Cores return no regions before a ROM is loaded and during
+                // teardown. Re-entering unconditionally would fetch again on an
+                // empty result and loop over XPC forever.
+                guard !self.memoryRegions.isEmpty else {
+                    NSSound.beep()
+                    return
+                }
                 self.searchClicked(nil)
             }
             return
@@ -1029,7 +1064,7 @@ final class CheatSearchViewController: NSViewController {
 
 extension CheatSearchViewController: NSTableViewDataSource {
     func numberOfRows(in tableView: NSTableView) -> Int {
-        return searchResults.count
+        return min(searchResults.count, Self.displayLimit)
     }
 }
 

--- a/OpenEmu/CheatSearchViewController.swift
+++ b/OpenEmu/CheatSearchViewController.swift
@@ -812,7 +812,8 @@ final class CheatSearchViewController: NSViewController {
             return
         }
 
-        let rawCode = "\(address):\(hexValue.uppercased())"
+        let paddedValue = String(repeating: "0", count: max(0, selectedDataSize * 2 - hexValue.count)) + hexValue.uppercased()
+        let rawCode = "\(address):\(paddedValue)"
         let name = titleField.stringValue.isEmpty ? rawCode : titleField.stringValue
         let enabled = enableCheck.state == .on
 
@@ -882,7 +883,10 @@ final class CheatSearchViewController: NSViewController {
         }
     }
 
+    private var isRebuildingCombo = false
+
     @objc private func dataSizeChanged(_ sender: Any?) {
+        guard !isRebuildingCombo else { return }
         UserDefaults.standard.set(dataSizeCombo.indexOfSelectedItem, forKey: Self.dataSizeKey)
         reloadTable()
     }
@@ -897,6 +901,7 @@ final class CheatSearchViewController: NSViewController {
             return
         }
         
+        isRebuildingCombo = true
         let previousSize = availableDataSizes.isEmpty ? 0 : selectedDataSize
         availableDataSizes = newSizes
         
@@ -907,6 +912,7 @@ final class CheatSearchViewController: NSViewController {
                 : String(format: NSLocalizedString("%d bytes", comment: "Cheat Search data size option"), size)
             dataSizeCombo.addItem(withTitle: title)
         }
+        isRebuildingCombo = false
     }
 
     @objc private func comparisonChanged(_ sender: Any?) {

--- a/OpenEmu/CheatSearchViewController.swift
+++ b/OpenEmu/CheatSearchViewController.swift
@@ -608,6 +608,17 @@ final class CheatSearchViewController: NSViewController {
             targetValue = parseInputValue(thisValueTextField.stringValue, dataType: dataType, dataSize: dataSize)
         }
 
+        if !searchResults.isEmpty {
+            if compareTo == .storedValue && searchResults.first?.storedValue == nil {
+                NSSound.beep()
+                return
+            }
+            if compareTo == .previousValue && searchResults.first?.previousValue == nil {
+                NSSound.beep()
+                return
+            }
+        }
+
         if searchResults.isEmpty {
             let regions = memoryRegions
             showLoadingIndicator()

--- a/OpenEmu/CheatSearchViewController.swift
+++ b/OpenEmu/CheatSearchViewController.swift
@@ -134,6 +134,7 @@ final class CheatSearchViewController: NSViewController {
     private var searchButton: NSButton!
     private var storeValuesButton: NSButton!
     private var addCheatButton: NSButton!
+    private var resultsCountLabel: NSTextField!
 
     override func loadView() {
         view = NSView(frame: NSRect(x: 0, y: 0, width: 620, height: 480))
@@ -205,6 +206,24 @@ final class CheatSearchViewController: NSViewController {
     private func reloadTable() {
         tableView.reloadData()
         tableView.deselectAll(nil)
+        updateResultsCountLabel()
+    }
+
+    private func updateResultsCountLabel() {
+        let count = searchResults.count
+        if count == 0 {
+            resultsCountLabel.stringValue = ""
+        } else if count == 1 {
+            resultsCountLabel.stringValue = String(
+                format: NSLocalizedString("%@ result found 🎯", comment: "Cheat Search single result count"),
+                NumberFormatter.localizedString(from: NSNumber(value: count), number: .decimal)
+            )
+        } else {
+            resultsCountLabel.stringValue = String(
+                format: NSLocalizedString("%@ results found", comment: "Cheat Search result count"),
+                NumberFormatter.localizedString(from: NSNumber(value: count), number: .decimal)
+            )
+        }
     }
 
     private func showLoadingIndicator() {
@@ -385,6 +404,16 @@ final class CheatSearchViewController: NSViewController {
         addCheatButton.isEnabled = false
         stack.addArrangedSubview(storeRow.2)
         storeRow.2.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        resultsCountLabel = NSTextField(labelWithString: "")
+        resultsCountLabel.alignment = .center
+        resultsCountLabel.textColor = .secondaryLabelColor
+        resultsCountLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+        resultsCountLabel.maximumNumberOfLines = 1
+        resultsCountLabel.lineBreakMode = .byTruncatingTail
+        resultsCountLabel.drawsBackground = false
+        stack.addArrangedSubview(resultsCountLabel)
+        resultsCountLabel.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
 
         let bottomSpacer = NSView()
         bottomSpacer.setContentHuggingPriority(.defaultLow, for: .vertical)

--- a/OpenEmu/CheatSearchViewController.swift
+++ b/OpenEmu/CheatSearchViewController.swift
@@ -88,6 +88,8 @@ final class CheatSearchViewController: NSViewController {
     }
 
     private var searchResults: [SearchResult] = []
+    private var loadingSpinner: NSProgressIndicator?
+    private var isPopulating = false
 
     private var addressHexDigits: Int {
         memoryRegions.map { Int($0.addressBytes) * 2 }.max() ?? 8
@@ -197,6 +199,48 @@ final class CheatSearchViewController: NSViewController {
         }
     }
 
+    // MARK: - Loading Indicator
+
+    private func reloadTable() {
+        tableView.reloadData()
+        tableView.deselectAll(nil)
+    }
+
+    private func showLoadingIndicator() {
+        isPopulating = true
+        searchButton.isEnabled = false
+        addCheatButton.isEnabled = false
+        resetButton.isEnabled = false
+        storeValuesButton.isEnabled = false
+
+        if loadingSpinner == nil {
+            let spinner = NSProgressIndicator()
+            spinner.style = .spinning
+            spinner.controlSize = .regular
+            spinner.translatesAutoresizingMaskIntoConstraints = false
+            scrollView.superview?.addSubview(spinner)
+            NSLayoutConstraint.activate([
+                spinner.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
+                spinner.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor),
+            ])
+            loadingSpinner = spinner
+        }
+        loadingSpinner?.startAnimation(nil)
+        loadingSpinner?.isHidden = false
+        tableView.deselectAll(nil)
+        tableView.isEnabled = false
+    }
+
+    private func hideLoadingIndicator() {
+        isPopulating = false
+        searchButton.isEnabled = true
+        resetButton.isEnabled = true
+        storeValuesButton.isEnabled = true
+        loadingSpinner?.stopAnimation(nil)
+        loadingSpinner?.isHidden = true
+        tableView.isEnabled = true
+    }
+
     // MARK: - Memory Reading
 
     func readMemoryFromCore() {
@@ -215,32 +259,50 @@ final class CheatSearchViewController: NSViewController {
     }
 
     private func populateFullMemory() {
-        var results: [SearchResult] = []
+        let regions = memoryRegions
+        showLoadingIndicator()
 
-        for region in memoryRegions {
-            let data = region.data
-            let baseAddress = UInt32(region.address)
-            let byteCount = data.count
-            let stride = Int(region.minDataBytes)
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            var totalCount = 0
+            for region in regions {
+                totalCount += region.data.count / Int(region.minDataBytes)
+            }
+            var results: [SearchResult] = []
+            results.reserveCapacity(totalCount)
 
-            data.withUnsafeBytes { buffer in
-                var offset = 0
-                while offset <= byteCount - 1 {
-                    let available = min(4, byteCount - offset)
-                    let value = readValue(from: buffer, at: offset, size: available)
-                    results.append(SearchResult(
-                        address: baseAddress + UInt32(offset),
-                        currentValue: value,
-                        previousValue: nil,
-                        storedValue: nil
-                    ))
-                    offset += stride
+            for region in regions {
+                let data = region.data
+                let baseAddress = UInt32(region.address)
+                let byteCount = data.count
+                let stride = Int(region.minDataBytes)
+
+                data.withUnsafeBytes { buffer in
+                    var offset = 0
+                    while offset <= byteCount - 1 {
+                        let available = min(4, byteCount - offset)
+                        var value: UInt64 = 0
+                        for i in 0..<available {
+                            value |= UInt64(buffer[offset + i]) << (i * 8)
+                        }
+                        results.append(SearchResult(
+                            address: baseAddress + UInt32(offset),
+                            currentValue: value,
+                            previousValue: nil,
+                            storedValue: nil
+                        ))
+                        offset += stride
+                    }
                 }
             }
-        }
 
-        searchResults = results
-        tableView.reloadData()
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.searchResults = results
+                self.hideLoadingIndicator()
+                print("[CheatSearch] Populated \(results.count) addresses")
+                self.reloadTable()
+            }
+        }
     }
 
     private var isUpdatingValues = false
@@ -248,6 +310,7 @@ final class CheatSearchViewController: NSViewController {
     private func updateCurrentValues() {
         guard !searchResults.isEmpty, !memoryRegions.isEmpty, !isUpdatingValues else { return }
         isUpdatingValues = true
+        showLoadingIndicator()
 
         let regions = memoryRegions
         var results = searchResults
@@ -281,7 +344,8 @@ final class CheatSearchViewController: NSViewController {
                 guard let self = self else { return }
                 self.searchResults = results
                 self.isUpdatingValues = false
-                self.tableView.reloadData()
+                self.hideLoadingIndicator()
+                self.reloadTable()
             }
         }
     }
@@ -296,6 +360,7 @@ final class CheatSearchViewController: NSViewController {
         tableView.delegate = self
         tableView.headerView = NSTableHeaderView()
         tableView.style = .fullWidth
+        tableView.doubleAction = #selector(tableDoubleClicked(_:))
 
         let addressColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("address"))
         addressColumn.title = NSLocalizedString("Address", comment: "Cheat Search table column header")
@@ -531,6 +596,8 @@ final class CheatSearchViewController: NSViewController {
     // MARK: - Actions
 
     @objc private func searchClicked(_ sender: Any?) {
+        guard !isPopulating else { return }
+
         let dataSize = selectedDataSize
         let dataType = selectedDataType
         let comparison = selectedComparison
@@ -542,66 +609,93 @@ final class CheatSearchViewController: NSViewController {
         }
 
         if searchResults.isEmpty {
-            var results: [SearchResult] = []
+            let regions = memoryRegions
+            showLoadingIndicator()
 
-            for region in memoryRegions {
-                let data = region.data
-                let baseAddress = UInt32(region.address)
-                let byteCount = data.count
-                let stride = Int(region.minDataBytes)
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                var results: [SearchResult] = []
 
-                guard byteCount >= dataSize else { continue }
+                for region in regions {
+                    let data = region.data
+                    let baseAddress = UInt32(region.address)
+                    let byteCount = data.count
+                    let stride = Int(region.minDataBytes)
 
-                data.withUnsafeBytes { buffer in
-                    var offset = 0
-                    while offset <= byteCount - dataSize {
-                        let fullValue = readValue(from: buffer, at: offset, size: min(4, byteCount - offset))
+                    guard byteCount >= dataSize else { continue }
 
-                        let referenceValue: UInt64
-                        switch compareTo {
-                        case .thisValue:
-                            referenceValue = targetValue
-                        default:
-                            referenceValue = fullValue
+                    data.withUnsafeBytes { buffer in
+                        var offset = 0
+                        while offset <= byteCount - dataSize {
+                            let fullValue = self?.readValue(from: buffer, at: offset, size: min(4, byteCount - offset)) ?? 0
+
+                            let referenceValue: UInt64
+                            switch compareTo {
+                            case .thisValue:
+                                referenceValue = targetValue
+                            default:
+                                referenceValue = fullValue
+                            }
+
+                            if self?.compare(fullValue, to: referenceValue, operation: comparison, dataType: dataType, dataSize: dataSize) == true {
+                                results.append(SearchResult(
+                                    address: baseAddress + UInt32(offset),
+                                    currentValue: fullValue,
+                                    previousValue: nil,
+                                    storedValue: nil
+                                ))
+                            }
+                            offset += stride
                         }
-
-                        if compare(fullValue, to: referenceValue, operation: comparison, dataType: dataType, dataSize: dataSize) {
-                            results.append(SearchResult(
-                                address: baseAddress + UInt32(offset),
-                                currentValue: fullValue,
-                                previousValue: nil,
-                                storedValue: nil
-                            ))
-                        }
-                        offset += stride
                     }
                 }
+
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    self.searchResults = results
+                    self.hideLoadingIndicator()
+                    print("[CheatSearch] Search results: \(results.count)")
+                    self.reloadTable()
+                }
             }
-
-            searchResults = results
         } else {
-            searchResults = searchResults.compactMap { result in
-                let referenceValue: UInt64?
-                switch compareTo {
-                case .storedValue:
-                    referenceValue = result.storedValue
-                case .previousValue:
-                    referenceValue = result.previousValue
-                case .thisValue:
-                    referenceValue = targetValue
+            showLoadingIndicator()
+            let currentResults = searchResults
+
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                let filtered = currentResults.compactMap { result -> SearchResult? in
+                    let referenceValue: UInt64?
+                    switch compareTo {
+                    case .storedValue:
+                        referenceValue = result.storedValue
+                    case .previousValue:
+                        referenceValue = result.previousValue
+                    case .thisValue:
+                        referenceValue = targetValue
+                    }
+
+                    guard let ref = referenceValue else { return result }
+
+                    guard self?.compare(result.currentValue, to: ref, operation: comparison, dataType: dataType, dataSize: dataSize) == true else {
+                        return nil
+                    }
+
+                    return result
                 }
 
-                guard let ref = referenceValue else { return result }
-
-                guard compare(result.currentValue, to: ref, operation: comparison, dataType: dataType, dataSize: dataSize) else {
-                    return nil
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    self.searchResults = filtered
+                    self.hideLoadingIndicator()
+                    print("[CheatSearch] Search results: \(filtered.count)")
+                    self.reloadTable()
                 }
-
-                return result
             }
         }
+    }
 
-        tableView.reloadData()
+    @objc private func tableDoubleClicked(_ sender: Any?) {
+        guard tableView.selectedRow >= 0 else { return }
+        addCheatClicked(sender)
     }
 
     @objc private func addCheatClicked(_ sender: Any?) {
@@ -745,14 +839,26 @@ final class CheatSearchViewController: NSViewController {
 
     @objc private func resetClicked(_ sender: Any?) {
         searchResults = []
+        reloadTable()
         readMemoryFromCore()
     }
 
     @objc private func storeValuesClicked(_ sender: Any?) {
-        for i in 0..<searchResults.count {
-            searchResults[i].storedValue = searchResults[i].currentValue
+        showLoadingIndicator()
+        var results = searchResults
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            for i in 0..<results.count {
+                results[i].storedValue = results[i].currentValue
+            }
+
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.searchResults = results
+                self.hideLoadingIndicator()
+                self.reloadTable()
+            }
         }
-        tableView.reloadData()
     }
 
     @objc private func windowDidBecomeMain(_ notification: Notification) {
@@ -768,7 +874,7 @@ final class CheatSearchViewController: NSViewController {
             let index = tag - Self.dataTypeTagBase
             selectRadio(in: dataTypeRadios, index: index)
             UserDefaults.standard.set(index, forKey: Self.dataTypeKey)
-            tableView.reloadData()
+            reloadTable()
         } else if tag >= Self.compareToTagBase && tag < Self.compareToTagBase + 100 {
             let index = tag - Self.compareToTagBase
             selectRadio(in: compareToRadios, index: index)
@@ -778,7 +884,7 @@ final class CheatSearchViewController: NSViewController {
 
     @objc private func dataSizeChanged(_ sender: Any?) {
         UserDefaults.standard.set(dataSizeCombo.indexOfSelectedItem, forKey: Self.dataSizeKey)
-        tableView.reloadData()
+        reloadTable()
     }
 
     private func rebuildDataSizeCombo() {

--- a/OpenEmu/CheatSearchViewController.swift
+++ b/OpenEmu/CheatSearchViewController.swift
@@ -169,6 +169,7 @@ final class CheatSearchViewController: NSViewController {
         rightSide.widthAnchor.constraint(equalTo: mainSplit.widthAnchor, multiplier: 0.38).isActive = true
 
         restoreSavedSelections()
+        updateControlStates()
     }
 
     // MARK: - Persist / Restore Selections
@@ -235,7 +236,7 @@ final class CheatSearchViewController: NSViewController {
         isPopulating = false
         searchButton.isEnabled = true
         resetButton.isEnabled = true
-        storeValuesButton.isEnabled = true
+        updateControlStates()
         loadingSpinner?.stopAnimation(nil)
         loadingSpinner?.isHidden = true
         tableView.isEnabled = true
@@ -250,57 +251,8 @@ final class CheatSearchViewController: NSViewController {
             guard let self = self else { return }
             self.memoryRegions = regions.sorted { $0.address < $1.address }
             self.rebuildDataSizeCombo()
-            if self.searchResults.isEmpty {
-                self.populateFullMemory()
-            } else {
+            if !self.searchResults.isEmpty {
                 self.updateCurrentValues()
-            }
-        }
-    }
-
-    private func populateFullMemory() {
-        let regions = memoryRegions
-        showLoadingIndicator()
-
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            var totalCount = 0
-            for region in regions {
-                totalCount += region.data.count / Int(region.minDataBytes)
-            }
-            var results: [SearchResult] = []
-            results.reserveCapacity(totalCount)
-
-            for region in regions {
-                let data = region.data
-                let baseAddress = UInt32(region.address)
-                let byteCount = data.count
-                let stride = Int(region.minDataBytes)
-
-                data.withUnsafeBytes { buffer in
-                    var offset = 0
-                    while offset <= byteCount - stride {
-                        let available = min(4, byteCount - offset)
-                        var value: UInt64 = 0
-                        for i in 0..<available {
-                            value |= UInt64(buffer[offset + i]) << (i * 8)
-                        }
-                        results.append(SearchResult(
-                            address: baseAddress + UInt32(offset),
-                            currentValue: value,
-                            previousValue: nil,
-                            storedValue: nil
-                        ))
-                        offset += stride
-                    }
-                }
-            }
-
-            DispatchQueue.main.async {
-                guard let self else { return }
-                self.searchResults = results
-                self.hideLoadingIndicator()
-                // print("[CheatSearch] Populated \(results.count) addresses")
-                self.reloadTable()
             }
         }
     }
@@ -598,6 +550,20 @@ final class CheatSearchViewController: NSViewController {
     @objc private func searchClicked(_ sender: Any?) {
         guard !isPopulating else { return }
 
+        // Fetch memory regions first if not yet loaded
+        if memoryRegions.isEmpty {
+            guard let document = gameDocument else { return }
+            showLoadingIndicator()
+            document.fetchReadableMemoryRegions { [weak self] regions in
+                guard let self = self else { return }
+                self.memoryRegions = regions.sorted { $0.address < $1.address }
+                self.rebuildDataSizeCombo()
+                self.hideLoadingIndicator()
+                self.searchClicked(nil)
+            }
+            return
+        }
+
         let dataSize = selectedDataSize
         let dataType = selectedDataType
         let comparison = selectedComparison
@@ -852,6 +818,7 @@ final class CheatSearchViewController: NSViewController {
     @objc private func resetClicked(_ sender: Any?) {
         searchResults = []
         reloadTable()
+        updateControlStates()
         readMemoryFromCore()
     }
 
@@ -928,6 +895,24 @@ final class CheatSearchViewController: NSViewController {
 
     @objc private func comparisonChanged(_ sender: Any?) {
         UserDefaults.standard.set(comparisonCombo.indexOfSelectedItem, forKey: Self.comparisonKey)
+    }
+
+    /// Update enabled state of Stored/Previous radios and Store Values button
+    private func updateControlStates() {
+        let hasResults = !searchResults.isEmpty
+        let hasPrevious = hasResults && searchResults.first?.previousValue != nil
+        let hasStored = hasResults && searchResults.first?.storedValue != nil
+
+        compareToRadios[CompareTo.storedValue.rawValue].isEnabled = hasStored
+        compareToRadios[CompareTo.previousValue.rawValue].isEnabled = hasPrevious
+        storeValuesButton.isEnabled = hasResults
+
+        // If the selected radio is disabled, switch to This Value
+        let selectedIdx = compareToRadios.firstIndex(where: { $0.state == .on }) ?? 0
+        if !compareToRadios[selectedIdx].isEnabled {
+            selectRadio(in: compareToRadios, index: CompareTo.thisValue.rawValue)
+            UserDefaults.standard.set(CompareTo.thisValue.rawValue, forKey: Self.compareToKey)
+        }
     }
 
     // MARK: - Search Helpers

--- a/OpenEmu/CheatSearchViewController.swift
+++ b/OpenEmu/CheatSearchViewController.swift
@@ -278,7 +278,7 @@ final class CheatSearchViewController: NSViewController {
 
                 data.withUnsafeBytes { buffer in
                     var offset = 0
-                    while offset <= byteCount - 1 {
+                    while offset <= byteCount - stride {
                         let available = min(4, byteCount - offset)
                         var value: UInt64 = 0
                         for i in 0..<available {

--- a/OpenEmu/CheatSearchViewController.swift
+++ b/OpenEmu/CheatSearchViewController.swift
@@ -1,0 +1,945 @@
+// Copyright (c) 2026, OpenEmu Team
+// Author: Leonardo Kasperavičius
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Cocoa
+import OpenEmuBase
+
+final class CheatSearchViewController: NSViewController {
+
+    // MARK: - UserDefaults keys
+    private static let dataSizeKey = "cheatSearch.dataSize"
+    private static let dataTypeKey = "cheatSearch.dataType"
+    private static let comparisonKey = "cheatSearch.comparison"
+    private static let compareToKey = "cheatSearch.compareTo"
+
+    // MARK: - Enums
+
+    private enum DataType: Int {
+        case unsigned = 0
+        case signed = 1
+        case hexadecimal = 2
+    }
+
+    private enum Comparison: Int {
+        case lessThan = 0
+        case greaterThan = 1
+        case lessOrEqual = 2
+        case greaterOrEqual = 3
+        case equal = 4
+        case notEqual = 5
+    }
+
+    private enum CompareTo: Int {
+        case storedValue = 0
+        case previousValue = 1
+        case thisValue = 2
+    }
+
+    private static let dataTypeTagBase = 100
+    private static let compareToTagBase = 200
+
+    private var selectedDataType: DataType {
+        DataType(rawValue: dataTypeRadios.firstIndex(where: { $0.state == .on }) ?? 0) ?? .unsigned
+    }
+
+    private var selectedComparison: Comparison {
+        Comparison(rawValue: comparisonCombo.indexOfSelectedItem) ?? .equal
+    }
+
+    private var selectedCompareTo: CompareTo {
+        CompareTo(rawValue: compareToRadios.firstIndex(where: { $0.state == .on }) ?? 0) ?? .storedValue
+    }
+
+    // MARK: - Document reference
+    weak var gameDocument: OEGameDocument?
+
+    // MARK: - Memory Cache
+    private(set) var memoryRegions: [OEMemoryRegionDescriptor] = []
+
+    // MARK: - Search Results
+
+    private struct SearchResult {
+        let address: UInt32
+        var currentValue: UInt64
+        var previousValue: UInt64?
+        var storedValue: UInt64?
+    }
+
+    private var searchResults: [SearchResult] = []
+
+    private var addressHexDigits: Int {
+        memoryRegions.map { Int($0.addressBytes) * 2 }.max() ?? 8
+    }
+
+    private var addressFormatString: String {
+        "%0\(addressHexDigits)X"
+    }
+
+    private var minDataBytes: Int {
+        memoryRegions.map { Int($0.minDataBytes) }.max() ?? 1
+    }
+
+    // MARK: - Table View
+    private var tableView: NSTableView!
+    private var scrollView: NSScrollView!
+
+    // MARK: - Data Size combo
+    private var dataSizeCombo: NSPopUpButton!
+    private var availableDataSizes: [Int] = [1, 2, 3, 4]
+
+    private var selectedDataSize: Int {
+        let index = dataSizeCombo.indexOfSelectedItem
+        guard index >= 0, index < availableDataSizes.count else {
+            return availableDataSizes.first ?? 1
+        }
+        return availableDataSizes[index]
+    }
+
+    // MARK: - Data Type radios
+    private var dataTypeRadios: [NSButton] = []
+
+    // MARK: - Comparison combo
+    private var comparisonCombo: NSPopUpButton!
+
+    // MARK: - Compare To radios
+    private var compareToRadios: [NSButton] = []
+    private var thisValueTextField: NSTextField!
+
+    // MARK: - Buttons
+    private var resetButton: NSButton!
+    private var searchButton: NSButton!
+    private var storeValuesButton: NSButton!
+    private var addCheatButton: NSButton!
+
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 620, height: 480))
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(windowDidBecomeMain(_:)), name: NSWindow.didBecomeMainNotification, object: nil)
+
+        let mainSplit = NSStackView()
+        mainSplit.orientation = .horizontal
+        mainSplit.spacing = 12
+        mainSplit.translatesAutoresizingMaskIntoConstraints = false
+        mainSplit.edgeInsets = NSEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+        view.addSubview(mainSplit)
+
+        NSLayoutConstraint.activate([
+            mainSplit.topAnchor.constraint(equalTo: view.topAnchor),
+            mainSplit.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            mainSplit.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            mainSplit.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        scrollView = makeTableView()
+        mainSplit.addArrangedSubview(scrollView)
+
+        let rightSide = makeRightSide()
+        mainSplit.addArrangedSubview(rightSide)
+
+        scrollView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        rightSide.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        rightSide.widthAnchor.constraint(equalTo: mainSplit.widthAnchor, multiplier: 0.38).isActive = true
+
+        restoreSavedSelections()
+    }
+
+    // MARK: - Persist / Restore Selections
+
+    private func restoreSavedSelections() {
+        let defaults = UserDefaults.standard
+
+        let dataSize = defaults.integer(forKey: Self.dataSizeKey)
+        if dataSize >= 0 && dataSize < dataSizeCombo.numberOfItems {
+            dataSizeCombo.selectItem(at: dataSize)
+        }
+
+        let dataType = defaults.integer(forKey: Self.dataTypeKey)
+        selectRadio(in: dataTypeRadios, index: dataType)
+
+        let comparison = defaults.integer(forKey: Self.comparisonKey)
+        if comparison >= 0 && comparison < comparisonCombo.numberOfItems {
+            comparisonCombo.selectItem(at: comparison)
+        }
+
+        let compareTo = defaults.integer(forKey: Self.compareToKey)
+        selectRadio(in: compareToRadios, index: compareTo)
+    }
+
+    private func selectRadio(in radios: [NSButton], index: Int) {
+        for (i, radio) in radios.enumerated() {
+            radio.state = (i == index) ? .on : .off
+        }
+    }
+
+    // MARK: - Memory Reading
+
+    func readMemoryFromCore() {
+        guard let document = gameDocument else { return }
+
+        document.fetchReadableMemoryRegions { [weak self] regions in
+            guard let self = self else { return }
+            self.memoryRegions = regions.sorted { $0.address < $1.address }
+            self.rebuildDataSizeCombo()
+            if self.searchResults.isEmpty {
+                self.populateFullMemory()
+            } else {
+                self.updateCurrentValues()
+            }
+        }
+    }
+
+    private func populateFullMemory() {
+        var results: [SearchResult] = []
+
+        for region in memoryRegions {
+            let data = region.data
+            let baseAddress = UInt32(region.address)
+            let byteCount = data.count
+            let stride = Int(region.minDataBytes)
+
+            data.withUnsafeBytes { buffer in
+                var offset = 0
+                while offset <= byteCount - 1 {
+                    let available = min(4, byteCount - offset)
+                    let value = readValue(from: buffer, at: offset, size: available)
+                    results.append(SearchResult(
+                        address: baseAddress + UInt32(offset),
+                        currentValue: value,
+                        previousValue: nil,
+                        storedValue: nil
+                    ))
+                    offset += stride
+                }
+            }
+        }
+
+        searchResults = results
+        tableView.reloadData()
+    }
+
+    private var isUpdatingValues = false
+
+    private func updateCurrentValues() {
+        guard !searchResults.isEmpty, !memoryRegions.isEmpty, !isUpdatingValues else { return }
+        isUpdatingValues = true
+
+        let regions = memoryRegions
+        var results = searchResults
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            for region in regions {
+                let regionStart = UInt32(region.address)
+                let regionEnd = regionStart + UInt32(region.data.count)
+                let byteCount = region.data.count
+
+                region.data.withUnsafeBytes { buffer in
+                    for i in 0..<results.count {
+                        let address = results[i].address
+                        guard address >= regionStart && address < regionEnd else { continue }
+
+                        let offset = Int(address - regionStart)
+                        let available = min(4, byteCount - offset)
+                        guard available > 0 else { continue }
+
+                        var value: UInt64 = 0
+                        for b in 0..<available {
+                            value |= UInt64(buffer[offset + b]) << (b * 8)
+                        }
+                        results[i].previousValue = results[i].currentValue
+                        results[i].currentValue = value
+                    }
+                }
+            }
+
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.searchResults = results
+                self.isUpdatingValues = false
+                self.tableView.reloadData()
+            }
+        }
+    }
+
+    // MARK: - Left Side (Table)
+
+    private func makeTableView() -> NSScrollView {
+        tableView = NSTableView()
+        tableView.usesAlternatingRowBackgroundColors = true
+        tableView.allowsMultipleSelection = false
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.headerView = NSTableHeaderView()
+        tableView.style = .fullWidth
+
+        let addressColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("address"))
+        addressColumn.title = NSLocalizedString("Address", comment: "Cheat Search table column header")
+        addressColumn.width = 80
+        addressColumn.minWidth = 60
+        tableView.addTableColumn(addressColumn)
+
+        let currentColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("current"))
+        currentColumn.title = NSLocalizedString("Current", comment: "Cheat Search table column header")
+        currentColumn.width = 70
+        currentColumn.minWidth = 50
+        tableView.addTableColumn(currentColumn)
+
+        let previousColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("previous"))
+        previousColumn.title = NSLocalizedString("Previous", comment: "Cheat Search table column header")
+        previousColumn.width = 70
+        previousColumn.minWidth = 50
+        tableView.addTableColumn(previousColumn)
+
+        let storedColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("stored"))
+        storedColumn.title = NSLocalizedString("Stored", comment: "Cheat Search table column header")
+        storedColumn.width = 70
+        storedColumn.minWidth = 50
+        tableView.addTableColumn(storedColumn)
+
+        let sv = NSScrollView()
+        sv.documentView = tableView
+        sv.hasVerticalScroller = true
+        sv.hasHorizontalScroller = false
+        sv.borderType = .bezelBorder
+
+        return sv
+    }
+
+    // MARK: - Right Side (Controls)
+
+    private func makeRightSide() -> NSView {
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 12
+
+        let dataTypePanel = makeDataTypePanel()
+        stack.addArrangedSubview(dataTypePanel)
+        dataTypePanel.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        let comparisonPanel = makeComparisonPanel()
+        stack.addArrangedSubview(comparisonPanel)
+        comparisonPanel.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        let searchRow = makeButtonRow(
+            leftTitle: NSLocalizedString("Reset", comment: "Cheat Search button"),
+            leftAction: #selector(resetClicked(_:)),
+            rightTitle: NSLocalizedString("Search", comment: "Cheat Search button"),
+            rightAction: #selector(searchClicked(_:))
+        )
+        resetButton = searchRow.0
+        searchButton = searchRow.1
+        stack.addArrangedSubview(searchRow.2)
+        searchRow.2.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        let storeRow = makeButtonRow(
+            leftTitle: NSLocalizedString("Store Values", comment: "Cheat Search button"),
+            leftAction: #selector(storeValuesClicked(_:)),
+            rightTitle: NSLocalizedString("Add Cheat…", comment: "Cheat Search button"),
+            rightAction: #selector(addCheatClicked(_:))
+        )
+        storeValuesButton = storeRow.0
+        addCheatButton = storeRow.1
+        addCheatButton.isEnabled = false
+        stack.addArrangedSubview(storeRow.2)
+        storeRow.2.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        let bottomSpacer = NSView()
+        bottomSpacer.setContentHuggingPriority(.defaultLow, for: .vertical)
+        stack.addArrangedSubview(bottomSpacer)
+
+        return stack
+    }
+
+    // MARK: - Data Type Panel
+
+    private func makeDataTypePanel() -> NSBox {
+        let box = NSBox()
+        box.titlePosition = .noTitle
+
+        let outerStack = NSStackView()
+        outerStack.orientation = .vertical
+        outerStack.alignment = .leading
+        outerStack.spacing = 8
+        outerStack.translatesAutoresizingMaskIntoConstraints = false
+
+        box.contentView?.addSubview(outerStack)
+        if let contentView = box.contentView {
+            NSLayoutConstraint.activate([
+                outerStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+                outerStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 8),
+                outerStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -8),
+                outerStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8),
+            ])
+        }
+
+        let sizeRow = NSStackView()
+        sizeRow.orientation = .horizontal
+        sizeRow.spacing = 8
+
+        let sizeLabel = NSTextField(labelWithString: NSLocalizedString("Data Size", comment: "Cheat Search options group"))
+        sizeLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+
+        dataSizeCombo = NSPopUpButton(frame: .zero, pullsDown: false)
+        dataSizeCombo.target = self
+        dataSizeCombo.action = #selector(dataSizeChanged(_:))
+        rebuildDataSizeCombo()
+        dataSizeCombo.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        sizeRow.addArrangedSubview(sizeLabel)
+        sizeRow.addArrangedSubview(dataSizeCombo)
+        outerStack.addArrangedSubview(sizeRow)
+        sizeRow.widthAnchor.constraint(equalTo: outerStack.widthAnchor).isActive = true
+
+        let dataTypeOptions = [
+            NSLocalizedString("Unsigned (>=0)", comment: "Cheat Search data type option"),
+            NSLocalizedString("Signed (+/-)", comment: "Cheat Search data type option"),
+            NSLocalizedString("Hexadecimal", comment: "Cheat Search data type option"),
+        ]
+
+        for (index, option) in dataTypeOptions.enumerated() {
+            let radio = NSButton(radioButtonWithTitle: option, target: self, action: #selector(radioChanged(_:)))
+            radio.tag = Self.dataTypeTagBase + index
+            radio.state = (index == 0) ? .on : .off
+            outerStack.addArrangedSubview(radio)
+            dataTypeRadios.append(radio)
+        }
+
+        return box
+    }
+
+    // MARK: - Comparison Panel
+
+    private func makeComparisonPanel() -> NSBox {
+        let box = NSBox()
+        box.titlePosition = .noTitle
+
+        let outerStack = NSStackView()
+        outerStack.orientation = .vertical
+        outerStack.alignment = .leading
+        outerStack.spacing = 8
+        outerStack.translatesAutoresizingMaskIntoConstraints = false
+
+        box.contentView?.addSubview(outerStack)
+        if let contentView = box.contentView {
+            NSLayoutConstraint.activate([
+                outerStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+                outerStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 8),
+                outerStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -8),
+                outerStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8),
+            ])
+        }
+
+        let compRow = NSStackView()
+        compRow.orientation = .horizontal
+        compRow.spacing = 8
+
+        let compLabel = NSTextField(labelWithString: NSLocalizedString("Comparison", comment: "Cheat Search options group"))
+        compLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+
+        comparisonCombo = NSPopUpButton(frame: .zero, pullsDown: false)
+        comparisonCombo.target = self
+        comparisonCombo.action = #selector(comparisonChanged(_:))
+        comparisonCombo.addItems(withTitles: ["<", ">", "<=", ">=", "=", "!="])
+        comparisonCombo.selectItem(at: 4)
+        comparisonCombo.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        compRow.addArrangedSubview(compLabel)
+        compRow.addArrangedSubview(comparisonCombo)
+        outerStack.addArrangedSubview(compRow)
+        compRow.widthAnchor.constraint(equalTo: outerStack.widthAnchor).isActive = true
+
+        let storedRadio = NSButton(radioButtonWithTitle: NSLocalizedString("Stored Value", comment: "Cheat Search compare to option"), target: self, action: #selector(radioChanged(_:)))
+        storedRadio.tag = Self.compareToTagBase + CompareTo.storedValue.rawValue
+        storedRadio.state = .on
+        outerStack.addArrangedSubview(storedRadio)
+        compareToRadios.append(storedRadio)
+
+        let previousRadio = NSButton(radioButtonWithTitle: NSLocalizedString("Previous Value", comment: "Cheat Search compare to option"), target: self, action: #selector(radioChanged(_:)))
+        previousRadio.tag = Self.compareToTagBase + CompareTo.previousValue.rawValue
+        previousRadio.state = .off
+        outerStack.addArrangedSubview(previousRadio)
+        compareToRadios.append(previousRadio)
+
+        let thisValueRow = NSStackView()
+        thisValueRow.orientation = .horizontal
+        thisValueRow.spacing = 8
+
+        let thisValueRadio = NSButton(radioButtonWithTitle: NSLocalizedString("This Value:", comment: "Cheat Search compare to option"), target: self, action: #selector(radioChanged(_:)))
+        thisValueRadio.tag = Self.compareToTagBase + CompareTo.thisValue.rawValue
+        thisValueRadio.state = .off
+        thisValueRadio.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        compareToRadios.append(thisValueRadio)
+
+        thisValueTextField = NSTextField()
+        thisValueTextField.placeholderString = "0"
+        thisValueTextField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        thisValueRow.addArrangedSubview(thisValueRadio)
+        thisValueRow.addArrangedSubview(thisValueTextField)
+        outerStack.addArrangedSubview(thisValueRow)
+        thisValueRow.widthAnchor.constraint(equalTo: outerStack.widthAnchor).isActive = true
+
+        return box
+    }
+
+    // MARK: - Button Row Helper
+
+    private func makeButtonRow(leftTitle: String, leftAction: Selector, rightTitle: String, rightAction: Selector) -> (NSButton, NSButton, NSView) {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.spacing = 8
+        row.distribution = .fillEqually
+
+        let leftButton = NSButton(title: leftTitle, target: self, action: leftAction)
+        leftButton.bezelStyle = .rounded
+
+        let rightButton = NSButton(title: rightTitle, target: self, action: rightAction)
+        rightButton.bezelStyle = .rounded
+
+        row.addArrangedSubview(leftButton)
+        row.addArrangedSubview(rightButton)
+
+        return (leftButton, rightButton, row)
+    }
+
+    // MARK: - Actions
+
+    @objc private func searchClicked(_ sender: Any?) {
+        let dataSize = selectedDataSize
+        let dataType = selectedDataType
+        let comparison = selectedComparison
+        let compareTo = selectedCompareTo
+
+        var targetValue: UInt64 = 0
+        if compareTo == .thisValue {
+            targetValue = parseInputValue(thisValueTextField.stringValue, dataType: dataType, dataSize: dataSize)
+        }
+
+        if searchResults.isEmpty {
+            var results: [SearchResult] = []
+
+            for region in memoryRegions {
+                let data = region.data
+                let baseAddress = UInt32(region.address)
+                let byteCount = data.count
+                let stride = Int(region.minDataBytes)
+
+                guard byteCount >= dataSize else { continue }
+
+                data.withUnsafeBytes { buffer in
+                    var offset = 0
+                    while offset <= byteCount - dataSize {
+                        let fullValue = readValue(from: buffer, at: offset, size: min(4, byteCount - offset))
+
+                        let referenceValue: UInt64
+                        switch compareTo {
+                        case .thisValue:
+                            referenceValue = targetValue
+                        default:
+                            referenceValue = fullValue
+                        }
+
+                        if compare(fullValue, to: referenceValue, operation: comparison, dataType: dataType, dataSize: dataSize) {
+                            results.append(SearchResult(
+                                address: baseAddress + UInt32(offset),
+                                currentValue: fullValue,
+                                previousValue: nil,
+                                storedValue: nil
+                            ))
+                        }
+                        offset += stride
+                    }
+                }
+            }
+
+            searchResults = results
+        } else {
+            searchResults = searchResults.compactMap { result in
+                let referenceValue: UInt64?
+                switch compareTo {
+                case .storedValue:
+                    referenceValue = result.storedValue
+                case .previousValue:
+                    referenceValue = result.previousValue
+                case .thisValue:
+                    referenceValue = targetValue
+                }
+
+                guard let ref = referenceValue else { return result }
+
+                guard compare(result.currentValue, to: ref, operation: comparison, dataType: dataType, dataSize: dataSize) else {
+                    return nil
+                }
+
+                return result
+            }
+        }
+
+        tableView.reloadData()
+    }
+
+    @objc private func addCheatClicked(_ sender: Any?) {
+        let selectedRow = tableView.selectedRow
+        guard selectedRow >= 0, selectedRow < searchResults.count else { return }
+        let result = searchResults[selectedRow]
+        let addressString = String(format: addressFormatString, result.address)
+
+        guard let parentWindow = view.window else { return }
+
+        let sheet = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 380, height: 180),
+                             styleMask: [.titled],
+                             backing: .buffered,
+                             defer: true)
+        sheet.title = NSLocalizedString("Add Cheat", comment: "Cheat Search add cheat sheet title")
+
+        let contentView = sheet.contentView!
+
+        let grid = NSGridView(numberOfColumns: 2, rows: 0)
+        grid.translatesAutoresizingMaskIntoConstraints = false
+        grid.rowAlignment = .lastBaseline
+        grid.column(at: 0).xPlacement = .trailing
+        grid.columnSpacing = 8
+        grid.rowSpacing = 10
+        contentView.addSubview(grid)
+
+        let titleLabel = NSTextField(labelWithString: NSLocalizedString("Title:", comment: ""))
+        let titleField = NSTextField()
+        titleField.placeholderString = NSLocalizedString("Cheat Description", comment: "")
+        grid.addRow(with: [titleLabel, titleField])
+
+        let addressLabel = NSTextField(labelWithString: NSLocalizedString("Address:", comment: ""))
+        let addressField = NSTextField(labelWithString: addressString)
+        addressField.font = NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+        grid.addRow(with: [addressLabel, addressField])
+
+        let valueLabel = NSTextField(labelWithString: NSLocalizedString("Value (Hex):", comment: ""))
+        let valueField = NSTextField()
+        valueField.placeholderString = "FF"
+        grid.addRow(with: [valueLabel, valueField])
+
+        grid.column(at: 1).width = 220
+
+        let enableCheck = NSButton(checkboxWithTitle: NSLocalizedString("Enable now", comment: "Cheats button label"), target: nil, action: nil)
+        enableCheck.state = .on
+        enableCheck.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(enableCheck)
+
+        let cancelButton = NSButton(title: NSLocalizedString("Cancel", comment: ""), target: nil, action: nil)
+        cancelButton.bezelStyle = .rounded
+        cancelButton.keyEquivalent = "\u{1b}"
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(cancelButton)
+
+        let addButton = NSButton(title: NSLocalizedString("Add Cheat", comment: ""), target: nil, action: nil)
+        addButton.bezelStyle = .rounded
+        addButton.keyEquivalent = "\r"
+        addButton.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(addButton)
+
+        NSLayoutConstraint.activate([
+            grid.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20),
+            grid.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            contentView.trailingAnchor.constraint(equalTo: grid.trailingAnchor, constant: 20),
+
+            enableCheck.topAnchor.constraint(equalTo: grid.bottomAnchor, constant: 16),
+            enableCheck.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+
+            addButton.topAnchor.constraint(equalTo: enableCheck.bottomAnchor, constant: 16),
+            contentView.trailingAnchor.constraint(equalTo: addButton.trailingAnchor, constant: 20),
+            contentView.bottomAnchor.constraint(equalTo: addButton.bottomAnchor, constant: 20),
+
+            cancelButton.lastBaselineAnchor.constraint(equalTo: addButton.lastBaselineAnchor),
+            addButton.leadingAnchor.constraint(equalTo: cancelButton.trailingAnchor, constant: 8),
+        ])
+
+        cancelButton.target = self
+        cancelButton.action = #selector(sheetCancel(_:))
+        addButton.target = self
+        addButton.action = #selector(sheetAddCheat(_:))
+
+        self.sheetTitleField = titleField
+        self.sheetValueField = valueField
+        self.sheetAddressString = addressString
+        self.sheetEnableCheck = enableCheck
+
+        parentWindow.beginSheet(sheet)
+    }
+
+    // MARK: - Add Cheat Sheet
+
+    private var sheetTitleField: NSTextField?
+    private var sheetValueField: NSTextField?
+    private var sheetAddressString: String?
+    private var sheetEnableCheck: NSButton?
+
+    @objc private func sheetCancel(_ sender: Any?) {
+        guard let sheet = view.window?.attachedSheet else { return }
+        view.window?.endSheet(sheet, returnCode: .cancel)
+    }
+
+    @objc private func sheetAddCheat(_ sender: Any?) {
+        guard let sheet = view.window?.attachedSheet,
+              let titleField = sheetTitleField,
+              let valueField = sheetValueField,
+              let address = sheetAddressString,
+              let enableCheck = sheetEnableCheck,
+              let document = gameDocument
+        else { return }
+
+        let hexValue = valueField.stringValue.trimmingCharacters(in: .whitespaces)
+        guard !hexValue.isEmpty else {
+            NSSound.beep()
+            return
+        }
+
+        let rawCode = "\(address):\(hexValue.uppercased())"
+        let name = titleField.stringValue.isEmpty ? rawCode : titleField.stringValue
+        let enabled = enableCheck.state == .on
+
+        // Derive addressBytes/minDataBytes from the region that contains this address
+        let addressBytes = memoryRegions.first.map { $0.addressBytes } ?? 2
+        let dataBytes = memoryRegions.first.map { $0.minDataBytes } ?? 1
+
+        let converted = OEGameDocument.convertCheatSearchCode(
+            rawCode,
+            for: document.systemIdentifier,
+            addressBytes: addressBytes,
+            minDataBytes: dataBytes
+        )
+
+        document.addCheatFromSearch(code: converted.code, type: converted.type, name: name, enabled: enabled)
+
+        view.window?.endSheet(sheet, returnCode: .OK)
+
+        sheetTitleField = nil
+        sheetValueField = nil
+        sheetAddressString = nil
+        sheetEnableCheck = nil
+    }
+
+    @objc private func resetClicked(_ sender: Any?) {
+        searchResults = []
+        readMemoryFromCore()
+    }
+
+    @objc private func storeValuesClicked(_ sender: Any?) {
+        for i in 0..<searchResults.count {
+            searchResults[i].storedValue = searchResults[i].currentValue
+        }
+        tableView.reloadData()
+    }
+
+    @objc private func windowDidBecomeMain(_ notification: Notification) {
+        guard notification.object as? NSWindow === view.window else { return }
+        readMemoryFromCore()
+    }
+
+    @objc private func radioChanged(_ sender: Any?) {
+        guard let radio = sender as? NSButton else { return }
+        let tag = radio.tag
+
+        if tag >= Self.dataTypeTagBase && tag < Self.compareToTagBase {
+            let index = tag - Self.dataTypeTagBase
+            selectRadio(in: dataTypeRadios, index: index)
+            UserDefaults.standard.set(index, forKey: Self.dataTypeKey)
+            tableView.reloadData()
+        } else if tag >= Self.compareToTagBase && tag < Self.compareToTagBase + 100 {
+            let index = tag - Self.compareToTagBase
+            selectRadio(in: compareToRadios, index: index)
+            UserDefaults.standard.set(index, forKey: Self.compareToKey)
+        }
+    }
+
+    @objc private func dataSizeChanged(_ sender: Any?) {
+        UserDefaults.standard.set(dataSizeCombo.indexOfSelectedItem, forKey: Self.dataSizeKey)
+        tableView.reloadData()
+    }
+
+    private func rebuildDataSizeCombo() {
+        let min = minDataBytes
+        let allSizes = [1, 2, 3, 4]
+        let newSizes = allSizes.filter { $0 >= min && $0 % min == 0 }
+        
+        // Skip rebuild if the combo already starts with the correct minimum size
+        if dataSizeCombo.numberOfItems > 0, let firstSize = newSizes.first, availableDataSizes.first == firstSize {
+            return
+        }
+        
+        let previousSize = availableDataSizes.isEmpty ? 0 : selectedDataSize
+        availableDataSizes = newSizes
+        
+        dataSizeCombo.removeAllItems()
+        for size in availableDataSizes {
+            let title = size == 1
+                ? NSLocalizedString("1 byte", comment: "Cheat Search data size option")
+                : String(format: NSLocalizedString("%d bytes", comment: "Cheat Search data size option"), size)
+            dataSizeCombo.addItem(withTitle: title)
+        }
+    }
+
+    @objc private func comparisonChanged(_ sender: Any?) {
+        UserDefaults.standard.set(comparisonCombo.indexOfSelectedItem, forKey: Self.comparisonKey)
+    }
+
+    // MARK: - Search Helpers
+
+    private func readValue(from buffer: UnsafeRawBufferPointer, at offset: Int, size: Int) -> UInt64 {
+        var value: UInt64 = 0
+        for i in 0..<size {
+            value |= UInt64(buffer[offset + i]) << (i * 8)
+        }
+        return value
+    }
+
+    private func compare(_ a: UInt64, to b: UInt64, operation: Comparison, dataType: DataType, dataSize: Int) -> Bool {
+        if dataType == .signed {
+            let sa = signExtend(a, size: dataSize)
+            let sb = signExtend(b, size: dataSize)
+            switch operation {
+            case .lessThan:       return sa < sb
+            case .greaterThan:    return sa > sb
+            case .lessOrEqual:    return sa <= sb
+            case .greaterOrEqual: return sa >= sb
+            case .equal:          return sa == sb
+            case .notEqual:       return sa != sb
+            }
+        } else {
+            let mask: UInt64 = (1 << (dataSize * 8)) - 1
+            let ma = a & mask
+            let mb = b & mask
+            switch operation {
+            case .lessThan:       return ma < mb
+            case .greaterThan:    return ma > mb
+            case .lessOrEqual:    return ma <= mb
+            case .greaterOrEqual: return ma >= mb
+            case .equal:          return ma == mb
+            case .notEqual:       return ma != mb
+            }
+        }
+    }
+
+    private func signExtend(_ value: UInt64, size: Int) -> Int64 {
+        switch size {
+        case 1: return Int64(Int8(bitPattern: UInt8(value & 0xFF)))
+        case 2: return Int64(Int16(bitPattern: UInt16(value & 0xFFFF)))
+        case 3:
+            if value & 0x800000 != 0 {
+                return Int64(bitPattern: value | 0xFFFFFFFFFF000000)
+            }
+            return Int64(value)
+        case 4: return Int64(Int32(bitPattern: UInt32(value & 0xFFFFFFFF)))
+        default: return Int64(bitPattern: value)
+        }
+    }
+
+    private func parseInputValue(_ text: String, dataType: DataType, dataSize: Int) -> UInt64 {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        let mask: UInt64 = (1 << (dataSize * 8)) - 1
+
+        switch dataType {
+        case .hexadecimal:
+            return (UInt64(trimmed, radix: 16) ?? 0) & mask
+        case .signed:
+            let signed = Int64(trimmed) ?? 0
+            return UInt64(bitPattern: signed) & mask
+        case .unsigned:
+            return (UInt64(trimmed) ?? 0) & mask
+        }
+    }
+
+    private func formatValue(_ value: UInt64, dataType: DataType, dataSize: Int) -> String {
+        let mask: UInt64 = (1 << (dataSize * 8)) - 1
+        let masked = value & mask
+
+        switch dataType {
+        case .hexadecimal:
+            return String(format: "%0\(dataSize * 2)llX", masked)
+        case .signed:
+            return "\(signExtend(value, size: dataSize))"
+        case .unsigned:
+            return "\(masked)"
+        }
+    }
+}
+
+// MARK: - NSTableViewDataSource
+
+extension CheatSearchViewController: NSTableViewDataSource {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        return searchResults.count
+    }
+}
+
+// MARK: - NSTableViewDelegate
+
+extension CheatSearchViewController: NSTableViewDelegate {
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard let identifier = tableColumn?.identifier else { return nil }
+        let result = searchResults[row]
+        let dataType = selectedDataType
+        let dataSize = selectedDataSize
+
+        let cellID = NSUserInterfaceItemIdentifier("CheatSearchCell")
+        let cell: NSTextField
+        if let existing = tableView.makeView(withIdentifier: cellID, owner: nil) as? NSTextField {
+            cell = existing
+        } else {
+            cell = NSTextField(labelWithString: "")
+            cell.identifier = cellID
+            cell.font = NSFont.monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+        }
+
+        switch identifier.rawValue {
+        case "address":
+            cell.stringValue = String(format: addressFormatString, result.address)
+        case "current":
+            cell.stringValue = formatValue(result.currentValue, dataType: dataType, dataSize: dataSize)
+        case "previous":
+            if let prev = result.previousValue {
+                cell.stringValue = formatValue(prev, dataType: dataType, dataSize: dataSize)
+            } else {
+                cell.stringValue = ""
+            }
+        case "stored":
+            if let stored = result.storedValue {
+                cell.stringValue = formatValue(stored, dataType: dataType, dataSize: dataSize)
+            } else {
+                cell.stringValue = ""
+            }
+        default:
+            break
+        }
+
+        return cell
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        addCheatButton.isEnabled = tableView.selectedRow >= 0
+    }
+}

--- a/OpenEmu/CheatSearchViewController.swift
+++ b/OpenEmu/CheatSearchViewController.swift
@@ -299,7 +299,7 @@ final class CheatSearchViewController: NSViewController {
                 guard let self else { return }
                 self.searchResults = results
                 self.hideLoadingIndicator()
-                print("[CheatSearch] Populated \(results.count) addresses")
+                // print("[CheatSearch] Populated \(results.count) addresses")
                 self.reloadTable()
             }
         }
@@ -653,7 +653,7 @@ final class CheatSearchViewController: NSViewController {
                     guard let self else { return }
                     self.searchResults = results
                     self.hideLoadingIndicator()
-                    print("[CheatSearch] Search results: \(results.count)")
+                    // print("[CheatSearch] Search results: \(results.count)")
                     self.reloadTable()
                 }
             }
@@ -686,7 +686,7 @@ final class CheatSearchViewController: NSViewController {
                     guard let self else { return }
                     self.searchResults = filtered
                     self.hideLoadingIndicator()
-                    print("[CheatSearch] Search results: \(filtered.count)")
+                    // print("[CheatSearch] Search results: \(filtered.count)")
                     self.reloadTable()
                 }
             }

--- a/OpenEmu/CheatSearchWindowController.swift
+++ b/OpenEmu/CheatSearchWindowController.swift
@@ -1,0 +1,61 @@
+// Copyright (c) 2026, OpenEmu Team
+// Author: Leonardo Kasperavičius
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Cocoa
+
+final class CheatSearchWindowController: NSWindowController {
+
+    weak var gameDocument: OEGameDocument?
+
+    init(document: OEGameDocument) {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 620, height: 480),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: true
+        )
+        window.title = NSLocalizedString("Cheat Search", comment: "Cheat Search window title")
+        window.isReleasedWhenClosed = false
+        window.setFrameAutosaveName("CheatSearchWindow")
+        window.minSize = NSSize(width: 520, height: 380)
+        window.standardWindowButton(.zoomButton)?.isEnabled = false
+        window.center()
+
+        super.init(window: window)
+        self.gameDocument = document
+
+        let viewController = CheatSearchViewController()
+        viewController.gameDocument = document
+        self.contentViewController = viewController
+    }
+
+    override func showWindow(_ sender: Any?) {
+        super.showWindow(sender)
+        (contentViewController as? CheatSearchViewController)?.readMemoryFromCore()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+}

--- a/OpenEmu/CheatSearchWindowController.swift
+++ b/OpenEmu/CheatSearchWindowController.swift
@@ -53,7 +53,6 @@ final class CheatSearchWindowController: NSWindowController {
 
     override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
-        (contentViewController as? CheatSearchViewController)?.readMemoryFromCore()
     }
 
     @available(*, unavailable)

--- a/OpenEmu/GameControlsBar.swift
+++ b/OpenEmu/GameControlsBar.swift
@@ -428,6 +428,12 @@ final class GameControlsBar: NSWindow {
         if hardcoreOn { item.isEnabled = false }
         menu.addItem(item)
 
+        if gameViewController.supportsCheatSearch {
+            let searchItem = NSMenuItem(title: NSLocalizedString("Cheat Search…", comment: ""), action: #selector(OEGameDocument.openCheatSearch(_:)), keyEquivalent: "")
+            if hardcoreOn { searchItem.isEnabled = false }
+            menu.addItem(searchItem)
+        }
+
         let cheats = gameViewController.document.cheats
         if !cheats.isEmpty {
             menu.addItem(.separator())

--- a/OpenEmu/GameViewController.swift
+++ b/OpenEmu/GameViewController.swift
@@ -251,7 +251,11 @@ final class GameViewController: NSViewController {
     var supportsCheats: Bool {
         document.supportsCheats
     }
-    
+
+    var supportsCheatSearch: Bool {
+        document.supportsCheatSearch
+    }
+
     var supportsSaveStates: Bool {
         document.supportsSaveStates
     }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1830,13 +1830,13 @@ final class OEGameDocument: NSDocument {
         case OESystemIdentifierNDS:
             return ConvertedCheat(code: Self.convertToActionReplayDS(code), type: OECheatTypeActionReplay)
         default:
-            return ConvertedCheat(code: Self.convertToPatch(code, addressBytes: addressBytes, minDataBytes: minDataBytes), type: OECheatTypeActionReplay)
+            return ConvertedCheat(code: Self.convertToRaw(code, addressBytes: addressBytes, minDataBytes: minDataBytes), type: OECheatTypeRaw)
         }
     }
 
-    // MARK: Patch format (ADDRESS:VALUE with padding and multi-byte splitting)
+    // MARK: Raw format (ADDRESS:VALUE with padding and multi-byte splitting)
 
-    private static func convertToPatch(_ code: String, addressBytes: UInt8, minDataBytes: UInt8) -> String {
+    private static func convertToRaw(_ code: String, addressBytes: UInt8, minDataBytes: UInt8) -> String {
         guard let colonIdx = code.firstIndex(of: ":") else { return code }
         let addressPart = String(code[code.startIndex..<colonIdx])
         let valuePart = String(code[code.index(after: colonIdx)...])

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -161,6 +161,7 @@ final class OEGameDocument: NSDocument {
     private(set) var displayModes: [[String: Any]] = []
     
     private var gameCoreManager: GameCoreManager?
+    private var cheatSearchWindowController: CheatSearchWindowController?
     private var retroAchievementsWindowController: NSWindowController?
     @objc dynamic private(set) var retroAchievementsSessionInfo: [String: Any]?
     private var retroAchievementsSuppressedUnlockIDs = Set<UInt32>()
@@ -659,7 +660,10 @@ final class OEGameDocument: NSDocument {
                 self.didShowRetroAchievementsBootPlacard = false
                 
                 self.gameCoreManager = nil
-                
+
+                self.cheatSearchWindowController?.close()
+                self.cheatSearchWindowController = nil
+
                 if let lastPlayStartDate = self.lastPlayStartDate {
                     self.rom.addTimeIntervalToPlayTime(abs(lastPlayStartDate.timeIntervalSinceNow))
                 }
@@ -1617,6 +1621,32 @@ final class OEGameDocument: NSDocument {
     
     var supportsCheats: Bool {
         return corePlugin.supportsCheatCode(forSystemIdentifier: systemPlugin.systemIdentifier)
+    }
+
+    var supportsCheatSearch: Bool {
+        return corePlugin.supportsCheatSearch(forSystemIdentifier: systemPlugin.systemIdentifier)
+    }
+
+    func fetchReadableMemoryRegions(completionHandler block: @escaping ([OEMemoryRegionDescriptor]) -> Void) {
+        gameCoreManager?.readableMemoryRegionDescriptors(completionHandler: block)
+    }
+
+    @IBAction func openCheatSearch(_ sender: Any?) {
+        if cheatSearchWindowController == nil {
+            cheatSearchWindowController = CheatSearchWindowController(document: self)
+        }
+        cheatSearchWindowController?.showWindow(self)
+    }
+
+    func addCheatFromSearch(code: String, type: String, name: String, enabled: Bool) {
+        let cheat = Cheat(code: code, type: type, name: name)
+        cheat.isUserAdded = true
+        if enabled {
+            cheat.isEnabled = true
+            setCheat(cheat)
+        }
+        cheats.append(cheat)
+        saveUserCheats()
     }
     
     /// In order to load cheats, we need the core plugin and the ROM to be set.

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1838,6 +1838,8 @@ final class OEGameDocument: NSDocument {
         switch systemIdentifier {
         case OESystemIdentifierN64:
             return ConvertedCheat(code: Self.convertToGameSharkN64(code), type: OECheatTypeGameShark)
+        case OESystemIdentifierPSX:
+            return ConvertedCheat(code: Self.convertToGameSharkPSX(code), type: OECheatTypeGameShark)
         case OESystemIdentifierGB:
             return ConvertedCheat(code: Self.convertToGameSharkGB(code), type: OECheatTypeGameShark)
         case OESystemIdentifierNDS:
@@ -1959,6 +1961,37 @@ final class OEGameDocument: NSDocument {
             } else {
                 let val8 = UInt8((value >> ((byteCount - offset - 1) * 8)) & 0xFF)
                 codes.append(String(format: "%08X%04X", 0x80000000 | addr, UInt16(val8)))
+                offset += 1
+            }
+        }
+        return codes.joined(separator: "+")
+    }
+
+    // MARK: PSX GameShark (TTAAAAAA VVVV — little-endian, 12 nybbles)
+
+    private static func convertToGameSharkPSX(_ code: String) -> String {
+        guard let colonIdx = code.firstIndex(of: ":") else { return code }
+        let addressPart = String(code[code.startIndex..<colonIdx])
+        let valuePart = String(code[code.index(after: colonIdx)...])
+
+        let address = UInt64(addressPart, radix: 16) ?? 0
+        let value = UInt64(valuePart, radix: 16) ?? 0
+        let byteCount = max(1, (valuePart.count + 1) / 2)
+
+        let baseAddr = UInt32(address & 0x00FFFFFF)
+        var codes: [String] = []
+        var offset = 0
+        while offset < byteCount {
+            let remaining = byteCount - offset
+            let addr = baseAddr + UInt32(offset)
+
+            if remaining >= 2 && (addr % 2 == 0) {
+                let val16 = UInt16((value >> (offset * 8)) & 0xFFFF)
+                codes.append(String(format: "%08X %04X", 0x80000000 | addr, val16))
+                offset += 2
+            } else {
+                let val8 = UInt8((value >> (offset * 8)) & 0xFF)
+                codes.append(String(format: "%08X %04X", 0x30000000 | addr, UInt16(val8)))
                 offset += 1
             }
         }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1782,7 +1782,146 @@ final class OEGameDocument: NSDocument {
             return defaultCheatFormat
         }
     }
-    
+
+    // MARK: - Cheat Search Code Conversion
+
+    struct ConvertedCheat {
+        let code: String
+        let type: String
+    }
+
+    /// Converts a raw cheat search code (ADDRESS:VALUE) to the native format expected by the core.
+    static func convertCheatSearchCode(_ code: String, for systemIdentifier: String, addressBytes: UInt8, minDataBytes: UInt8) -> ConvertedCheat {
+        switch systemIdentifier {
+        case OESystemIdentifierN64:
+            return ConvertedCheat(code: Self.convertToGameSharkN64(code), type: OECheatTypeGameShark)
+        case OESystemIdentifierGB, OESystemIdentifierGBA:
+            return ConvertedCheat(code: Self.convertToGameSharkGB(code), type: OECheatTypeGameShark)
+        case OESystemIdentifierNDS:
+            return ConvertedCheat(code: Self.convertToActionReplayDS(code), type: OECheatTypeActionReplay)
+        default:
+            return ConvertedCheat(code: Self.convertToPatch(code, addressBytes: addressBytes, minDataBytes: minDataBytes), type: OECheatTypeActionReplay)
+        }
+    }
+
+    // MARK: Patch format (ADDRESS:VALUE with padding and multi-byte splitting)
+
+    private static func convertToPatch(_ code: String, addressBytes: UInt8, minDataBytes: UInt8) -> String {
+        guard let colonIdx = code.firstIndex(of: ":") else { return code }
+        let addressPart = String(code[code.startIndex..<colonIdx])
+        let valuePart = String(code[code.index(after: colonIdx)...])
+
+        let hexDigits = Int(addressBytes) * 2
+        let address = UInt64(addressPart, radix: 16) ?? 0
+        let value = UInt64(valuePart, radix: 16) ?? 0
+        let byteCount = max(1, (valuePart.count + 1) / 2)
+
+        if byteCount <= Int(minDataBytes) {
+            let mask: UInt64 = (1 << (UInt64(minDataBytes) * 8)) - 1
+            let addrStr = String(format: "%0\(hexDigits)llX", address)
+            let valStr = String(format: "%0\(Int(minDataBytes) * 2)X", UInt32(value & mask))
+            return "\(addrStr):\(valStr)"
+        }
+
+        let chunkCount = (byteCount + Int(minDataBytes) - 1) / Int(minDataBytes)
+        let chunkMask: UInt64 = (1 << (UInt64(minDataBytes) * 8)) - 1
+        var codes: [String] = []
+        for i in 0..<chunkCount {
+            let chunk = UInt32((value >> (UInt64(i) * UInt64(minDataBytes) * 8)) & chunkMask)
+            let addr = address + UInt64(i) * UInt64(minDataBytes)
+            let addrStr = String(format: "%0\(hexDigits)llX", addr)
+            let valStr = String(format: "%0\(Int(minDataBytes) * 2)X", chunk)
+            codes.append("\(addrStr):\(valStr)")
+        }
+        return codes.joined(separator: "+")
+    }
+
+    // MARK: Game Boy GameShark (01VVLLHH)
+
+    private static func convertToGameSharkGB(_ code: String) -> String {
+        guard let colonIdx = code.firstIndex(of: ":") else { return code }
+        let addressPart = String(code[code.startIndex..<colonIdx])
+        let valuePart = String(code[code.index(after: colonIdx)...])
+
+        let address = UInt16(addressPart, radix: 16) ?? 0
+        let value = UInt64(valuePart, radix: 16) ?? 0
+        let byteCount = max(1, (valuePart.count + 1) / 2)
+
+        var codes: [String] = []
+        for i in 0..<byteCount {
+            let byte = UInt8((value >> (i * 8)) & 0xFF)
+            let addr = address &+ UInt16(i)
+            codes.append(String(format: "01%02X%02X%02X", byte, addr & 0xFF, (addr >> 8) & 0xFF))
+        }
+        return codes.joined(separator: "+")
+    }
+
+    // MARK: NDS Action Replay DS
+
+    private static func convertToActionReplayDS(_ code: String) -> String {
+        guard let colonIdx = code.firstIndex(of: ":") else { return code }
+        let addressPart = String(code[code.startIndex..<colonIdx])
+        let valuePart = String(code[code.index(after: colonIdx)...])
+
+        let address = UInt64(addressPart, radix: 16) ?? 0
+        let value = UInt64(valuePart, radix: 16) ?? 0
+        let byteCount = max(1, (valuePart.count + 1) / 2)
+
+        var codes: [String] = []
+        var offset = 0
+        while offset < byteCount {
+            let remaining = byteCount - offset
+            let addr28 = UInt32((address + UInt64(offset)) & 0x0FFFFFFF)
+            let shifted = value >> (offset * 8)
+
+            if remaining >= 4 && (addr28 % 4 == 0) {
+                let val32 = UInt32(shifted & 0xFFFFFFFF)
+                codes.append(String(format: "%08X %08X", 0x00000000 | addr28, val32))
+                offset += 4
+            } else if remaining >= 2 && (addr28 % 2 == 0) {
+                let val16 = UInt32(shifted & 0xFFFF)
+                codes.append(String(format: "%08X %08X", 0x10000000 | addr28, val16))
+                offset += 2
+            } else {
+                let val8 = UInt32(shifted & 0xFF)
+                codes.append(String(format: "%08X %08X", 0x20000000 | addr28, val8))
+                offset += 1
+            }
+        }
+        return codes.joined(separator: "\n")
+    }
+
+    // MARK: N64 GameShark (TTXXXXXX YYYY)
+
+    private static func convertToGameSharkN64(_ code: String) -> String {
+        guard let colonIdx = code.firstIndex(of: ":") else { return code }
+        let addressPart = String(code[code.startIndex..<colonIdx])
+        let valuePart = String(code[code.index(after: colonIdx)...])
+
+        let address = UInt64(addressPart, radix: 16) ?? 0
+        let value = UInt64(valuePart, radix: 16) ?? 0
+        let byteCount = max(1, (valuePart.count + 1) / 2)
+
+        let baseAddr = UInt32(address & 0x00FFFFFF)
+        var codes: [String] = []
+        var offset = 0
+        while offset < byteCount {
+            let remaining = byteCount - offset
+            let addr = baseAddr + UInt32(offset)
+
+            if remaining >= 2 && (addr % 2 == 0) {
+                let val16 = UInt16((value >> ((byteCount - offset - 2) * 8)) & 0xFFFF)
+                codes.append(String(format: "%08X%04X", 0x81000000 | addr, val16))
+                offset += 2
+            } else {
+                let val8 = UInt8((value >> ((byteCount - offset - 1) * 8)) & 0xFF)
+                codes.append(String(format: "%08X%04X", 0x80000000 | addr, UInt16(val8)))
+                offset += 1
+            }
+        }
+        return codes.joined(separator: "+")
+    }
+
     /// expects `sender.representedObject` to be a `Cheat` object
     @IBAction func toggleCheat(_ sender: AnyObject) {
         if isHardcoreModeEnabled { return }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1825,7 +1825,7 @@ final class OEGameDocument: NSDocument {
         switch systemIdentifier {
         case OESystemIdentifierN64:
             return ConvertedCheat(code: Self.convertToGameSharkN64(code), type: OECheatTypeGameShark)
-        case OESystemIdentifierGB, OESystemIdentifierGBA:
+        case OESystemIdentifierGB:
             return ConvertedCheat(code: Self.convertToGameSharkGB(code), type: OECheatTypeGameShark)
         case OESystemIdentifierNDS:
             return ConvertedCheat(code: Self.convertToActionReplayDS(code), type: OECheatTypeActionReplay)

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1770,7 +1770,7 @@ final class OEGameDocument: NSDocument {
 
     private static func cheatFormat(for systemIdentifier: String) -> CheatFormat {
         switch systemIdentifier {
-        case "openemu.system.n64":
+        case OESystemIdentifierN64:
             return CheatFormat(
                 placeholder: NSLocalizedString("12 hex chars per code, e.g. 8033B21D0064. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, N64"),
                 validationHint: NSLocalizedString("N64 codes must be 12 hex characters (8-char address + 4-char value), e.g. 8033B21D0064. Longer 16-char GameShark Pro / Action Replay codes are not supported by the Mupen64Plus core.", comment: "Add Cheat validation hint, N64"),
@@ -1784,31 +1784,31 @@ final class OEGameDocument: NSDocument {
                     }
                 }
             )
-        case "openemu.system.nes", "openemu.system.fds":
+        case OESystemIdentifierNES, OESystemIdentifierFDS:
             return CheatFormat(
                 placeholder: NSLocalizedString("Game Genie or raw hex (XXXX:YY). Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, NES"),
                 validationHint: "",
                 validator: nil
             )
-        case "openemu.system.snes":
+        case OESystemIdentifierSNES:
             return CheatFormat(
                 placeholder: NSLocalizedString("Game Genie or PAR codes. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, SNES"),
                 validationHint: "",
                 validator: nil
             )
-        case "openemu.system.gb", "openemu.system.gba":
+        case OESystemIdentifierGB, OESystemIdentifierGBA:
             return CheatFormat(
                 placeholder: NSLocalizedString("GameShark (no dash) or Game Genie (with dash). Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, Game Boy / GBA"),
                 validationHint: "",
                 validator: nil
             )
-        case "openemu.system.sg", "openemu.system.sms", "openemu.system.gg", "openemu.system.32x", "openemu.system.scd":
+        case OESystemIdentifierGenesis, OESystemIdentifierSMS, OESystemIdentifierGameGear, OESystemIdentifierSega32X, OESystemIdentifierSegaCD:
             return CheatFormat(
                 placeholder: NSLocalizedString("Game Genie or Action Replay. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, Sega"),
                 validationHint: "",
                 validator: nil
             )
-        case "openemu.system.psx":
+        case OESystemIdentifierPSX:
             return CheatFormat(
                 placeholder: NSLocalizedString("12 hex chars per code, e.g. 80097BA0270F. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, PSX"),
                 validationHint: NSLocalizedString("PSX GameShark codes must be 12 hex characters (e.g. 80097BA0270F). Type byte: 30=8-bit, 80=16-bit.", comment: "Add Cheat validation hint, PSX"),

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1808,6 +1808,19 @@ final class OEGameDocument: NSDocument {
                 validationHint: "",
                 validator: nil
             )
+        case "openemu.system.psx":
+            return CheatFormat(
+                placeholder: NSLocalizedString("12 hex chars per code, e.g. 80097BA0270F. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, PSX"),
+                validationHint: NSLocalizedString("PSX GameShark codes must be 12 hex characters (e.g. 80097BA0270F). Type byte: 30=8-bit, 80=16-bit.", comment: "Add Cheat validation hint, PSX"),
+                validator: { code in
+                    let parts = code.replacingOccurrences(of: " ", with: "")
+                                    .split(separator: "+")
+                    guard !parts.isEmpty else { return false }
+                    return parts.allSatisfy { p in
+                        p.count == 12 && p.allSatisfy { $0.isHexDigit }
+                    }
+                }
+            )
         default:
             return defaultCheatFormat
         }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1074,16 +1074,6 @@ final class OEGameDocument: NSDocument {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
 
-            // Moving to this document's own Cheat Search window is not "going to
-            // the background". Cheat search depends on the game continuing to run,
-            // since the whole workflow is changing a value in-game and searching
-            // again to narrow down candidates. Pausing here made the game look
-            // frozen the moment the window opened.
-            if let cheatSearchWindow = self.cheatSearchWindowController?.window,
-               cheatSearchWindow.isMainWindow || cheatSearchWindow.isKeyWindow {
-                return
-            }
-
             let backgroundPause = UserDefaults.standard.bool(forKey: OEBackgroundPauseKey)
             if backgroundPause && self.emulationStatus == .playing {
                 self.requestEmulationPauseRespectingRetroAchievementsHardcore { [weak self] paused in

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1937,7 +1937,10 @@ final class OEGameDocument: NSDocument {
     }
 
     // MARK: N64 GameShark (TTXXXXXX YYYY)
-
+    // Mupen64Plus stores RDRAM as host-native uint32 words; the cheat engine XORs byte/halfword
+    // addresses (S8=3, S16=2) to find the correct raw offset. We XOR here to convert the raw
+    // buffer offset (from cheat search) to the N64 virtual address the engine expects.
+    
     private static func convertToGameSharkN64(_ code: String) -> String {
         guard let colonIdx = code.firstIndex(of: ":") else { return code }
         let addressPart = String(code[code.startIndex..<colonIdx])
@@ -1952,15 +1955,19 @@ final class OEGameDocument: NSDocument {
         var offset = 0
         while offset < byteCount {
             let remaining = byteCount - offset
-            let addr = baseAddr + UInt32(offset)
+            let rawAddr = baseAddr + UInt32(offset)
 
-            if remaining >= 2 && (addr % 2 == 0) {
+            if remaining >= 2 && (rawAddr % 2 == 0) {
+                // Convert raw buffer offset to N64 virtual address (XOR 2 for halfword)
+                let n64Addr = rawAddr ^ 2
                 let val16 = UInt16((value >> ((byteCount - offset - 2) * 8)) & 0xFFFF)
-                codes.append(String(format: "%08X%04X", 0x81000000 | addr, val16))
+                codes.append(String(format: "%08X%04X", 0x81000000 | n64Addr, val16))
                 offset += 2
             } else {
+                // Convert raw buffer offset to N64 virtual address (XOR 3 for byte)
+                let n64Addr = rawAddr ^ 3
                 let val8 = UInt8((value >> ((byteCount - offset - 1) * 8)) & 0xFF)
-                codes.append(String(format: "%08X%04X", 0x80000000 | addr, UInt16(val8)))
+                codes.append(String(format: "%08X%04X", 0x80000000 | n64Addr, UInt16(val8)))
                 offset += 1
             }
         }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1068,11 +1068,28 @@ final class OEGameDocument: NSDocument {
     }
     
     @objc private func windowDidResignMain(_ notification: Notification) {
-        let backgroundPause = UserDefaults.standard.bool(forKey: OEBackgroundPauseKey)
-        if backgroundPause && emulationStatus == .playing {
-            requestEmulationPauseRespectingRetroAchievementsHardcore { [weak self] paused in
-                if paused {
-                    self?.pausedByGoingToBackground = true
+        // Deferred a turn so the incoming main window has been established:
+        // this fires before the new window takes over, so asking who is main
+        // right now would always come back empty.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+
+            // Moving to this document's own Cheat Search window is not "going to
+            // the background". Cheat search depends on the game continuing to run,
+            // since the whole workflow is changing a value in-game and searching
+            // again to narrow down candidates. Pausing here made the game look
+            // frozen the moment the window opened.
+            if let cheatSearchWindow = self.cheatSearchWindowController?.window,
+               cheatSearchWindow.isMainWindow || cheatSearchWindow.isKeyWindow {
+                return
+            }
+
+            let backgroundPause = UserDefaults.standard.bool(forKey: OEBackgroundPauseKey)
+            if backgroundPause && self.emulationStatus == .playing {
+                self.requestEmulationPauseRespectingRetroAchievementsHardcore { [weak self] paused in
+                    if paused {
+                        self?.pausedByGoingToBackground = true
+                    }
                 }
             }
         }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1810,8 +1810,8 @@ final class OEGameDocument: NSDocument {
             )
         case OESystemIdentifierPSX:
             return CheatFormat(
-                placeholder: NSLocalizedString("12 hex chars per code, e.g. 80097BA0270F. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, PSX"),
-                validationHint: NSLocalizedString("PSX GameShark codes must be 12 hex characters (e.g. 80097BA0270F). Type byte: 30=8-bit, 80=16-bit.", comment: "Add Cheat validation hint, PSX"),
+                placeholder: NSLocalizedString("12 hex chars per code, e.g. 80097BA0 270F. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, PSX"),
+                validationHint: NSLocalizedString("PSX GameShark codes must be 12 hex characters (e.g. 80097BA0 270F). Type byte: 30=8-bit, 80=16-bit.", comment: "Add Cheat validation hint, PSX"),
                 validator: { code in
                     let parts = code.replacingOccurrences(of: " ", with: "")
                                     .split(separator: "+")

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -668,6 +668,7 @@
 		DFDDE95A9D47B0C0B525780A /* OESaveSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F74677D2124A2E934C10038 /* OESaveSyncManager.swift */; };
 		E0D3D5AF068C48148780583F /* Keyboard-Mappings.plist in Resources */ = {isa = PBXBuildFile; fileRef = C6534A32E31642F3805D9A90 /* Keyboard-Mappings.plist */; };
 		E66ED795617D681F41CFA7BD /* MSX.oesystemplugin in Copy System Plugins to App Plugins */ = {isa = PBXBuildFile; fileRef = FEB6625B187B791800D14713 /* MSX.oesystemplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E8D9112BFB38FBCEEA8B22DD /* CheatSearchWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2D0AB7012BE11642E384A3 /* CheatSearchWindowController.swift */; };
 		E96D97FB8B2AA2119A472430 /* OpenEmuBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120C317112E1300E868A8 /* OpenEmuBase.framework */; };
 		EB3D03D02A24B3C100EBABCD /* 3DO.oesystemplugin in Copy System Plugins to App Plugins */ = {isa = PBXBuildFile; fileRef = 943F99B31707DF3700270E89 /* 3DO.oesystemplugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EF2FDBEB14CFFE06002A64F2 /* ControlsKeyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8396CC5514068DA90096F791 /* ControlsKeyButton.swift */; };
@@ -676,6 +677,7 @@
 		EFBD5D7814EFE19A00FBD1E0 /* NSColor+OEAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBD5D7714EFE19A00FBD1E0 /* NSColor+OEAdditions.swift */; };
 		EFBD5D7F14EFE26300FBD1E0 /* OEGridView.m in Sources */ = {isa = PBXBuildFile; fileRef = EFBD5D7C14EFE26300FBD1E0 /* OEGridView.m */; };
 		F2E3C43668DB03A494D5B16E /* OECredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A14B489D09FD1B597AD586 /* OECredentialStore.swift */; };
+		FC582061983BED3F49DE43B5 /* CheatSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8045ABD4E2FC2F0F03CEECB4 /* CheatSearchViewController.swift */; };
 		FEB66268187B792700D14713 /* OEMSXSystemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB66251187B62CA00D14713 /* OEMSXSystemController.swift */; };
 		FEB66269187B792700D14713 /* OEMSXSystemResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = FEB66254187B751700D14713 /* OEMSXSystemResponder.m */; };
 		FEB6626B187B797600D14713 /* OpenEmuSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6D120C417112E1300E868A8 /* OpenEmuSystem.framework */; };
@@ -1353,6 +1355,7 @@
 		7F313F1C2A607A18009EBADB /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/ControlLabels.strings; sourceTree = "<group>"; };
 		7F313F1D2A607A18009EBADB /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Debug.strings; sourceTree = "<group>"; };
 		7F313F1E2A607A19009EBADB /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		8045ABD4E2FC2F0F03CEECB4 /* CheatSearchViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheatSearchViewController.swift; sourceTree = "<group>"; };
 		820EB74A1483F9A2008EC398 /* NeoGeo Pocket.oesystemplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "NeoGeo Pocket.oesystemplugin"; sourceTree = BUILT_PRODUCTS_DIR; };
 		820EB7561483F9D3008EC398 /* OENGPSystemResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OENGPSystemResponder.h; sourceTree = "<group>"; };
 		820EB7571483F9D3008EC398 /* OENGPSystemResponder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OENGPSystemResponder.m; sourceTree = "<group>"; };
@@ -1924,6 +1927,7 @@
 		CC0011223344557201900001 /* ScreenScraperDevCredentials.template.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScreenScraperDevCredentials.template.swift; sourceTree = "<group>"; };
 		DBFF44DC2E9D79C700B30F0A /* OENESSystemResponderClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OENESSystemResponderClient.h; sourceTree = "<group>"; };
 		DBFF44DD2E9D79D400B30F0A /* OEFDSSystemResponderClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OEFDSSystemResponderClient.h; sourceTree = "<group>"; };
+		ED2D0AB7012BE11642E384A3 /* CheatSearchWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheatSearchWindowController.swift; sourceTree = "<group>"; };
 		EFBD5D7714EFE19A00FBD1E0 /* NSColor+OEAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSColor+OEAdditions.swift"; sourceTree = "<group>"; };
 		EFBD5D7B14EFE26300FBD1E0 /* OEGridView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEGridView.h; sourceTree = "<group>"; };
 		EFBD5D7C14EFE26300FBD1E0 /* OEGridView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEGridView.m; sourceTree = "<group>"; };
@@ -4088,6 +4092,8 @@
 				35F8401C31D685D3E7EAA048 /* OEGoogleDriveSecrets.template.swift */,
 				CC0011223344557201900001 /* ScreenScraperDevCredentials.template.swift */,
 				42A14B489D09FD1B597AD586 /* OECredentialStore.swift */,
+				ED2D0AB7012BE11642E384A3 /* CheatSearchWindowController.swift */,
+				8045ABD4E2FC2F0F03CEECB4 /* CheatSearchViewController.swift */,
 			);
 			name = OpenEmu;
 			sourceTree = "<group>";
@@ -6455,6 +6461,8 @@
 				F2E3C43668DB03A494D5B16E /* OECredentialStore.swift in Sources */,
 				C0D2C87DC8E70B924B0364B8 /* ArtworkFolderMatcher.swift in Sources */,
 				D3360575D5430005882E67D6 /* ArtworkImportReviewViewController.swift in Sources */,
+				E8D9112BFB38FBCEEA8B22DD /* CheatSearchWindowController.swift in Sources */,
+				FC582061983BED3F49DE43B5 /* CheatSearchViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenEmu/ar.lproj/Localizable.strings
+++ b/OpenEmu/ar.lproj/Localizable.strings
@@ -720,6 +720,8 @@ You can go to the Controls preferences to check which associations were affected
 	<string>هذه القيمة:</string>
 	<key>Cheat Description</key>
 	<string>وصف الغش</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>يتم عرض أول %1$@ من %2$@ تطابق، ضيّق نطاق البحث</string>
 
 </dict>
 </plist>

--- a/OpenEmu/ar.lproj/Localizable.strings
+++ b/OpenEmu/ar.lproj/Localizable.strings
@@ -676,5 +676,40 @@ You can go to the Controls preferences to check which associations were affected
 	<string>تم نقل مكتبتك بنجاح.</string>
 	<key>this guide</key>
 	<string>هذا الدليل</string>
+	<key>Add Cheat</key>
+	<string>أضف الغش</string>
+	<key>Cheat Search…</key>
+	<string>بحث عن شفرات غش…</string>
+	<key>Cheat Search</key>
+	<string>بحث عن شفرات غش</string>
+	<key>Store Values</key>
+	<string>تخزين القيم</string>
+	<key>Comparison</key>
+	<string>المقارنة</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>بدون إشارة (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>بإشارة (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>ستعشري</string>
+	<key>Data Size</key>
+	<string>حجم البيانات</string>
+	<key>1 byte</key>
+	<string>1 بايت</string>
+	<key>2 bytes</key>
+	<string>2 بايت</string>
+	<key>3 bytes</key>
+	<string>3 بايت</string>
+	<key>4 bytes</key>
+	<string>4 بايت</string>
+	<key>Stored Value</key>
+	<string>القيمة المخزنة</string>
+	<key>Previous Value</key>
+	<string>القيمة السابقة</string>
+	<key>This Value:</key>
+	<string>هذه القيمة:</string>
+	<key>Cheat Description</key>
+	<string>وصف الغش</string>
+
 </dict>
 </plist>

--- a/OpenEmu/ar.lproj/Localizable.strings
+++ b/OpenEmu/ar.lproj/Localizable.strings
@@ -696,12 +696,22 @@ You can go to the Controls preferences to check which associations were affected
 	<string>حجم البيانات</string>
 	<key>1 byte</key>
 	<string>1 بايت</string>
-	<key>2 bytes</key>
-	<string>2 بايت</string>
-	<key>3 bytes</key>
-	<string>3 بايت</string>
-	<key>4 bytes</key>
-	<string>4 بايت</string>
+	<key>%d bytes</key>
+	<string>%d بايت</string>
+	<key>Address</key>
+	<string>العنوان</string>
+	<key>Current</key>
+	<string>الحالي</string>
+	<key>Previous</key>
+	<string>السابق</string>
+	<key>Stored</key>
+	<string>المخزن</string>
+	<key>Reset</key>
+	<string>إعادة تعيين</string>
+	<key>Address:</key>
+	<string>العنوان:</string>
+	<key>Value (Hex):</key>
+	<string>القيمة (سداسي عشري):</string>
 	<key>Stored Value</key>
 	<string>القيمة المخزنة</string>
 	<key>Previous Value</key>

--- a/OpenEmu/ca.lproj/Localizable.strings
+++ b/OpenEmu/ca.lproj/Localizable.strings
@@ -750,6 +750,8 @@ Podeu anar a les preferències dels controls per comprovar quines associacions s
 	<string>Aquest valor:</string>
 	<key>Cheat Description</key>
 	<string>Descripció del truc</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>Es mostren les primeres %1$@ de %2$@ coincidències, refina la cerca</string>
 
 </dict>
 </plist>

--- a/OpenEmu/ca.lproj/Localizable.strings
+++ b/OpenEmu/ca.lproj/Localizable.strings
@@ -726,12 +726,22 @@ Podeu anar a les preferències dels controls per comprovar quines associacions s
 	<string>Mida de dades</string>
 	<key>1 byte</key>
 	<string>1 byte</string>
-	<key>2 bytes</key>
-	<string>2 bytes</string>
-	<key>3 bytes</key>
-	<string>3 bytes</string>
-	<key>4 bytes</key>
-	<string>4 bytes</string>
+	<key>%d bytes</key>
+	<string>%d bytes</string>
+	<key>Address</key>
+	<string>Adreça</string>
+	<key>Current</key>
+	<string>Actual</string>
+	<key>Previous</key>
+	<string>Anterior</string>
+	<key>Stored</key>
+	<string>Emmagatzemat</string>
+	<key>Reset</key>
+	<string>Restableix</string>
+	<key>Address:</key>
+	<string>Adreça:</string>
+	<key>Value (Hex):</key>
+	<string>Valor (Hex):</string>
 	<key>Stored Value</key>
 	<string>Valor emmagatzemat</string>
 	<key>Previous Value</key>

--- a/OpenEmu/ca.lproj/Localizable.strings
+++ b/OpenEmu/ca.lproj/Localizable.strings
@@ -706,5 +706,40 @@ Podeu anar a les preferències dels controls per comprovar quines associacions s
 	<string>S'ha mogut la biblioteca correctament.</string>
 	<key>this guide</key>
 	<string>aquesta guia</string>
+	<key>Add Cheat</key>
+	<string>Afegeix un truc</string>
+	<key>Cheat Search…</key>
+	<string>Cerca de trucs…</string>
+	<key>Cheat Search</key>
+	<string>Cerca de trucs</string>
+	<key>Store Values</key>
+	<string>Emmagatzema valors</string>
+	<key>Comparison</key>
+	<string>Comparació</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>Sense signe (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>Amb signe (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>Hexadecimal</string>
+	<key>Data Size</key>
+	<string>Mida de dades</string>
+	<key>1 byte</key>
+	<string>1 byte</string>
+	<key>2 bytes</key>
+	<string>2 bytes</string>
+	<key>3 bytes</key>
+	<string>3 bytes</string>
+	<key>4 bytes</key>
+	<string>4 bytes</string>
+	<key>Stored Value</key>
+	<string>Valor emmagatzemat</string>
+	<key>Previous Value</key>
+	<string>Valor anterior</string>
+	<key>This Value:</key>
+	<string>Aquest valor:</string>
+	<key>Cheat Description</key>
+	<string>Descripció del truc</string>
+
 </dict>
 </plist>

--- a/OpenEmu/de.lproj/Localizable.strings
+++ b/OpenEmu/de.lproj/Localizable.strings
@@ -748,6 +748,8 @@ Du kannst die Tastenbelegung in den Einstellungen unter „Steuerung“ überpr�
 	<string>Dieser Wert:</string>
 	<key>Cheat Description</key>
 	<string>Cheat-Beschreibung</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>Erste %1$@ von %2$@ Übereinstimmungen werden angezeigt, Suche eingrenzen</string>
 
 </dict>
 </plist>

--- a/OpenEmu/de.lproj/Localizable.strings
+++ b/OpenEmu/de.lproj/Localizable.strings
@@ -704,5 +704,40 @@ Du kannst die Tastenbelegung in den Einstellungen unter „Steuerung“ überpr�
 	<string>Die Mediathek wurde erfolgreich verschoben.</string>
 	<key>this guide</key>
 	<string>dieser Anleitung</string>
+	<key>Add Cheat</key>
+	<string>Cheat hinzufügen</string>
+	<key>Cheat Search…</key>
+	<string>Cheat-Suche…</string>
+	<key>Cheat Search</key>
+	<string>Cheat-Suche</string>
+	<key>Store Values</key>
+	<string>Werte speichern</string>
+	<key>Comparison</key>
+	<string>Vergleich</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>Ohne Vorzeichen (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>Mit Vorzeichen (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>Hexadezimal</string>
+	<key>Data Size</key>
+	<string>Datengröße</string>
+	<key>1 byte</key>
+	<string>1 Byte</string>
+	<key>2 bytes</key>
+	<string>2 Bytes</string>
+	<key>3 bytes</key>
+	<string>3 Bytes</string>
+	<key>4 bytes</key>
+	<string>4 Bytes</string>
+	<key>Stored Value</key>
+	<string>Gespeicherter Wert</string>
+	<key>Previous Value</key>
+	<string>Vorheriger Wert</string>
+	<key>This Value:</key>
+	<string>Dieser Wert:</string>
+	<key>Cheat Description</key>
+	<string>Cheat-Beschreibung</string>
+
 </dict>
 </plist>

--- a/OpenEmu/de.lproj/Localizable.strings
+++ b/OpenEmu/de.lproj/Localizable.strings
@@ -724,12 +724,22 @@ Du kannst die Tastenbelegung in den Einstellungen unter „Steuerung“ überpr�
 	<string>Datengröße</string>
 	<key>1 byte</key>
 	<string>1 Byte</string>
-	<key>2 bytes</key>
-	<string>2 Bytes</string>
-	<key>3 bytes</key>
-	<string>3 Bytes</string>
-	<key>4 bytes</key>
-	<string>4 Bytes</string>
+	<key>%d bytes</key>
+	<string>%d Bytes</string>
+	<key>Address</key>
+	<string>Adresse</string>
+	<key>Current</key>
+	<string>Aktuell</string>
+	<key>Previous</key>
+	<string>Vorherig</string>
+	<key>Stored</key>
+	<string>Gespeichert</string>
+	<key>Reset</key>
+	<string>Zurücksetzen</string>
+	<key>Address:</key>
+	<string>Adresse:</string>
+	<key>Value (Hex):</key>
+	<string>Wert (Hex):</string>
 	<key>Stored Value</key>
 	<string>Gespeicherter Wert</string>
 	<key>Previous Value</key>

--- a/OpenEmu/en.lproj/Localizable.strings
+++ b/OpenEmu/en.lproj/Localizable.strings
@@ -762,6 +762,8 @@ You can go to the Controls preferences to check which associations were affected
 	<string>This Value:</string>
 	<key>Cheat Description</key>
 	<string>Cheat Description</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>Showing first %1$@ of %2$@ matches, narrow your search</string>
 
 </dict>
 </plist>

--- a/OpenEmu/en.lproj/Localizable.strings
+++ b/OpenEmu/en.lproj/Localizable.strings
@@ -716,5 +716,40 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Your library was moved sucessfully.</string>
 	<key>this guide</key>
 	<string>this guide</string>
+	<key>Add Cheat</key>
+	<string>Add Cheat</string>
+	<key>Cheat Search…</key>
+	<string>Cheat Search…</string>
+	<key>Cheat Search</key>
+	<string>Cheat Search</string>
+	<key>Store Values</key>
+	<string>Store Values</string>
+	<key>Comparison</key>
+	<string>Comparison</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>Unsigned (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>Signed (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>Hexadecimal</string>
+	<key>Data Size</key>
+	<string>Data Size</string>
+	<key>1 byte</key>
+	<string>1 byte</string>
+	<key>2 bytes</key>
+	<string>2 bytes</string>
+	<key>3 bytes</key>
+	<string>3 bytes</string>
+	<key>4 bytes</key>
+	<string>4 bytes</string>
+	<key>Stored Value</key>
+	<string>Stored Value</string>
+	<key>Previous Value</key>
+	<string>Previous Value</string>
+	<key>This Value:</key>
+	<string>This Value:</string>
+	<key>Cheat Description</key>
+	<string>Cheat Description</string>
+
 </dict>
 </plist>

--- a/OpenEmu/en.lproj/Localizable.strings
+++ b/OpenEmu/en.lproj/Localizable.strings
@@ -736,12 +736,22 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Data Size</string>
 	<key>1 byte</key>
 	<string>1 byte</string>
-	<key>2 bytes</key>
-	<string>2 bytes</string>
-	<key>3 bytes</key>
-	<string>3 bytes</string>
-	<key>4 bytes</key>
-	<string>4 bytes</string>
+	<key>%d bytes</key>
+	<string>%d bytes</string>
+	<key>Address</key>
+	<string>Address</string>
+	<key>Current</key>
+	<string>Current</string>
+	<key>Previous</key>
+	<string>Previous</string>
+	<key>Stored</key>
+	<string>Stored</string>
+	<key>Reset</key>
+	<string>Reset</string>
+	<key>Address:</key>
+	<string>Address:</string>
+	<key>Value (Hex):</key>
+	<string>Value (Hex):</string>
 	<key>Stored Value</key>
 	<string>Stored Value</string>
 	<key>Previous Value</key>

--- a/OpenEmu/es.lproj/Localizable.strings
+++ b/OpenEmu/es.lproj/Localizable.strings
@@ -748,6 +748,8 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Este valor:</string>
 	<key>Cheat Description</key>
 	<string>Descripción de truco</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>Mostrando las primeras %1$@ de %2$@ coincidencias, refina la búsqueda</string>
 
 </dict>
 </plist>

--- a/OpenEmu/es.lproj/Localizable.strings
+++ b/OpenEmu/es.lproj/Localizable.strings
@@ -704,5 +704,40 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Su biblioteca fue movida correctamente.</string>
 	<key>this guide</key>
 	<string>esta guía</string>
+	<key>Add Cheat</key>
+	<string>Añadir truco</string>
+	<key>Cheat Search…</key>
+	<string>Buscar trucos…</string>
+	<key>Cheat Search</key>
+	<string>Buscar trucos</string>
+	<key>Store Values</key>
+	<string>Almacenar valores</string>
+	<key>Comparison</key>
+	<string>Comparación</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>Sin signo (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>Con signo (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>Hexadecimal</string>
+	<key>Data Size</key>
+	<string>Tamaño de dato</string>
+	<key>1 byte</key>
+	<string>1 byte</string>
+	<key>2 bytes</key>
+	<string>2 bytes</string>
+	<key>3 bytes</key>
+	<string>3 bytes</string>
+	<key>4 bytes</key>
+	<string>4 bytes</string>
+	<key>Stored Value</key>
+	<string>Valor almacenado</string>
+	<key>Previous Value</key>
+	<string>Valor anterior</string>
+	<key>This Value:</key>
+	<string>Este valor:</string>
+	<key>Cheat Description</key>
+	<string>Descripción de truco</string>
+
 </dict>
 </plist>

--- a/OpenEmu/es.lproj/Localizable.strings
+++ b/OpenEmu/es.lproj/Localizable.strings
@@ -724,12 +724,22 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Tamaño de dato</string>
 	<key>1 byte</key>
 	<string>1 byte</string>
-	<key>2 bytes</key>
-	<string>2 bytes</string>
-	<key>3 bytes</key>
-	<string>3 bytes</string>
-	<key>4 bytes</key>
-	<string>4 bytes</string>
+	<key>%d bytes</key>
+	<string>%d bytes</string>
+	<key>Address</key>
+	<string>Dirección</string>
+	<key>Current</key>
+	<string>Actual</string>
+	<key>Previous</key>
+	<string>Anterior</string>
+	<key>Stored</key>
+	<string>Almacenado</string>
+	<key>Reset</key>
+	<string>Restablecer</string>
+	<key>Address:</key>
+	<string>Dirección:</string>
+	<key>Value (Hex):</key>
+	<string>Valor (Hex):</string>
 	<key>Stored Value</key>
 	<string>Valor almacenado</string>
 	<key>Previous Value</key>

--- a/OpenEmu/fr.lproj/Localizable.strings
+++ b/OpenEmu/fr.lproj/Localizable.strings
@@ -746,6 +746,8 @@ Vous pouvez aller dans les préférences Contrôles pour vérifier les associati
 	<string>Cette valeur :</string>
 	<key>Cheat Description</key>
 	<string>Description du code</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>Affichage des %1$@ premières correspondances sur %2$@, affinez votre recherche</string>
 
 </dict>
 </plist>

--- a/OpenEmu/fr.lproj/Localizable.strings
+++ b/OpenEmu/fr.lproj/Localizable.strings
@@ -702,5 +702,40 @@ Vous pouvez aller dans les préférences Contrôles pour vérifier les associati
 	<string>Votre bibliothèque a été déplacée avec succès.</string>
 	<key>this guide</key>
 	<string>ce guide</string>
+	<key>Add Cheat</key>
+	<string>Ajouter un code</string>
+	<key>Cheat Search…</key>
+	<string>Recherche de codes…</string>
+	<key>Cheat Search</key>
+	<string>Recherche de codes</string>
+	<key>Store Values</key>
+	<string>Stocker les valeurs</string>
+	<key>Comparison</key>
+	<string>Comparaison</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>Non signé (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>Signé (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>Hexadécimal</string>
+	<key>Data Size</key>
+	<string>Taille des données</string>
+	<key>1 byte</key>
+	<string>1 octet</string>
+	<key>2 bytes</key>
+	<string>2 octets</string>
+	<key>3 bytes</key>
+	<string>3 octets</string>
+	<key>4 bytes</key>
+	<string>4 octets</string>
+	<key>Stored Value</key>
+	<string>Valeur stockée</string>
+	<key>Previous Value</key>
+	<string>Valeur précédente</string>
+	<key>This Value:</key>
+	<string>Cette valeur :</string>
+	<key>Cheat Description</key>
+	<string>Description du code</string>
+
 </dict>
 </plist>

--- a/OpenEmu/fr.lproj/Localizable.strings
+++ b/OpenEmu/fr.lproj/Localizable.strings
@@ -722,12 +722,22 @@ Vous pouvez aller dans les préférences Contrôles pour vérifier les associati
 	<string>Taille des données</string>
 	<key>1 byte</key>
 	<string>1 octet</string>
-	<key>2 bytes</key>
-	<string>2 octets</string>
-	<key>3 bytes</key>
-	<string>3 octets</string>
-	<key>4 bytes</key>
-	<string>4 octets</string>
+	<key>%d bytes</key>
+	<string>%d octets</string>
+	<key>Address</key>
+	<string>Adresse</string>
+	<key>Current</key>
+	<string>Actuel</string>
+	<key>Previous</key>
+	<string>Précédent</string>
+	<key>Stored</key>
+	<string>Enregistré</string>
+	<key>Reset</key>
+	<string>Réinitialiser</string>
+	<key>Address:</key>
+	<string>Adresse :</string>
+	<key>Value (Hex):</key>
+	<string>Valeur (Hex) :</string>
 	<key>Stored Value</key>
 	<string>Valeur stockée</string>
 	<key>Previous Value</key>

--- a/OpenEmu/it.lproj/Localizable.strings
+++ b/OpenEmu/it.lproj/Localizable.strings
@@ -752,6 +752,8 @@ Puoi andare nelle Preferenze Controlli per verificare quali impostazioni sono st
 	<string>Questo valore:</string>
 	<key>Cheat Description</key>
 	<string>Descrizione trucco</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>Mostrate le prime %1$@ di %2$@ corrispondenze, affina la ricerca</string>
 
 </dict>
 </plist>

--- a/OpenEmu/it.lproj/Localizable.strings
+++ b/OpenEmu/it.lproj/Localizable.strings
@@ -728,12 +728,22 @@ Puoi andare nelle Preferenze Controlli per verificare quali impostazioni sono st
 	<string>Dimensione dati</string>
 	<key>1 byte</key>
 	<string>1 byte</string>
-	<key>2 bytes</key>
-	<string>2 bytes</string>
-	<key>3 bytes</key>
-	<string>3 bytes</string>
-	<key>4 bytes</key>
-	<string>4 bytes</string>
+	<key>%d bytes</key>
+	<string>%d byte</string>
+	<key>Address</key>
+	<string>Indirizzo</string>
+	<key>Current</key>
+	<string>Attuale</string>
+	<key>Previous</key>
+	<string>Precedente</string>
+	<key>Stored</key>
+	<string>Memorizzato</string>
+	<key>Reset</key>
+	<string>Reimposta</string>
+	<key>Address:</key>
+	<string>Indirizzo:</string>
+	<key>Value (Hex):</key>
+	<string>Valore (Hex):</string>
 	<key>Stored Value</key>
 	<string>Valore memorizzato</string>
 	<key>Previous Value</key>

--- a/OpenEmu/it.lproj/Localizable.strings
+++ b/OpenEmu/it.lproj/Localizable.strings
@@ -708,5 +708,40 @@ Puoi andare nelle Preferenze Controlli per verificare quali impostazioni sono st
 	<string>La tua Libreria è stata spostata con successo.</string>
 	<key>this guide</key>
 	<string>la guida</string>
+	<key>Add Cheat</key>
+	<string>Aggiungi trucco</string>
+	<key>Cheat Search…</key>
+	<string>Cerca trucchi…</string>
+	<key>Cheat Search</key>
+	<string>Cerca trucchi</string>
+	<key>Store Values</key>
+	<string>Memorizza valori</string>
+	<key>Comparison</key>
+	<string>Confronto</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>Senza segno (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>Con segno (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>Esadecimale</string>
+	<key>Data Size</key>
+	<string>Dimensione dati</string>
+	<key>1 byte</key>
+	<string>1 byte</string>
+	<key>2 bytes</key>
+	<string>2 bytes</string>
+	<key>3 bytes</key>
+	<string>3 bytes</string>
+	<key>4 bytes</key>
+	<string>4 bytes</string>
+	<key>Stored Value</key>
+	<string>Valore memorizzato</string>
+	<key>Previous Value</key>
+	<string>Valore precedente</string>
+	<key>This Value:</key>
+	<string>Questo valore:</string>
+	<key>Cheat Description</key>
+	<string>Descrizione trucco</string>
+
 </dict>
 </plist>

--- a/OpenEmu/ja.lproj/Localizable.strings
+++ b/OpenEmu/ja.lproj/Localizable.strings
@@ -745,6 +745,8 @@ You can go to the Controls preferences to check which associations were affected
 	<string>この値:</string>
 	<key>Cheat Description</key>
 	<string>チートの説明</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>%2$@ 件中の最初の %1$@ 件を表示しています。検索条件を絞り込んでください</string>
 
 </dict>
 </plist>

--- a/OpenEmu/ja.lproj/Localizable.strings
+++ b/OpenEmu/ja.lproj/Localizable.strings
@@ -701,5 +701,40 @@ You can go to the Controls preferences to check which associations were affected
 	<string>ライブラリの移動が正常に完了しました。</string>
 	<key>this guide</key>
 	<string>ガイド</string>
+	<key>Add Cheat</key>
+	<string>チートコードを追加</string>
+	<key>Cheat Search…</key>
+	<string>チート検索…</string>
+	<key>Cheat Search</key>
+	<string>チート検索</string>
+	<key>Store Values</key>
+	<string>値を保存</string>
+	<key>Comparison</key>
+	<string>比較</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>符号なし (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>符号付き (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>16進数</string>
+	<key>Data Size</key>
+	<string>データサイズ</string>
+	<key>1 byte</key>
+	<string>1バイト</string>
+	<key>2 bytes</key>
+	<string>2バイト</string>
+	<key>3 bytes</key>
+	<string>3バイト</string>
+	<key>4 bytes</key>
+	<string>4バイト</string>
+	<key>Stored Value</key>
+	<string>保存済みの値</string>
+	<key>Previous Value</key>
+	<string>前回の値</string>
+	<key>This Value:</key>
+	<string>この値:</string>
+	<key>Cheat Description</key>
+	<string>チートの説明</string>
+
 </dict>
 </plist>

--- a/OpenEmu/ja.lproj/Localizable.strings
+++ b/OpenEmu/ja.lproj/Localizable.strings
@@ -721,12 +721,22 @@ You can go to the Controls preferences to check which associations were affected
 	<string>データサイズ</string>
 	<key>1 byte</key>
 	<string>1バイト</string>
-	<key>2 bytes</key>
-	<string>2バイト</string>
-	<key>3 bytes</key>
-	<string>3バイト</string>
-	<key>4 bytes</key>
-	<string>4バイト</string>
+	<key>%d bytes</key>
+	<string>%d バイト</string>
+	<key>Address</key>
+	<string>アドレス</string>
+	<key>Current</key>
+	<string>現在値</string>
+	<key>Previous</key>
+	<string>前回値</string>
+	<key>Stored</key>
+	<string>保存値</string>
+	<key>Reset</key>
+	<string>リセット</string>
+	<key>Address:</key>
+	<string>アドレス:</string>
+	<key>Value (Hex):</key>
+	<string>値 (16進数):</string>
 	<key>Stored Value</key>
 	<string>保存済みの値</string>
 	<key>Previous Value</key>

--- a/OpenEmu/nl.lproj/Localizable.strings
+++ b/OpenEmu/nl.lproj/Localizable.strings
@@ -749,6 +749,8 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Deze waarde:</string>
 	<key>Cheat Description</key>
 	<string>Beschrijving van cheat</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>Eerste %1$@ van %2$@ overeenkomsten weergegeven, verfijn je zoekopdracht</string>
 
 </dict>
 </plist>

--- a/OpenEmu/nl.lproj/Localizable.strings
+++ b/OpenEmu/nl.lproj/Localizable.strings
@@ -725,12 +725,22 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Gegevensgrootte</string>
 	<key>1 byte</key>
 	<string>1 byte</string>
-	<key>2 bytes</key>
-	<string>2 bytes</string>
-	<key>3 bytes</key>
-	<string>3 bytes</string>
-	<key>4 bytes</key>
-	<string>4 bytes</string>
+	<key>%d bytes</key>
+	<string>%d bytes</string>
+	<key>Address</key>
+	<string>Adres</string>
+	<key>Current</key>
+	<string>Huidig</string>
+	<key>Previous</key>
+	<string>Vorig</string>
+	<key>Stored</key>
+	<string>Opgeslagen</string>
+	<key>Reset</key>
+	<string>Herstel</string>
+	<key>Address:</key>
+	<string>Adres:</string>
+	<key>Value (Hex):</key>
+	<string>Waarde (Hex):</string>
 	<key>Stored Value</key>
 	<string>Opgeslagen waarde</string>
 	<key>Previous Value</key>

--- a/OpenEmu/nl.lproj/Localizable.strings
+++ b/OpenEmu/nl.lproj/Localizable.strings
@@ -705,5 +705,40 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Uw bibliotheek werd succesvol verplaatst.</string>
 	<key>this guide</key>
 	<string>deze handleiding</string>
+	<key>Add Cheat</key>
+	<string>Voeg cheat toe</string>
+	<key>Cheat Search…</key>
+	<string>Cheat zoeken…</string>
+	<key>Cheat Search</key>
+	<string>Cheat zoeken</string>
+	<key>Store Values</key>
+	<string>Waarden opslaan</string>
+	<key>Comparison</key>
+	<string>Vergelijking</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>Unsigned (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>Signed (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>Hexadecimaal</string>
+	<key>Data Size</key>
+	<string>Gegevensgrootte</string>
+	<key>1 byte</key>
+	<string>1 byte</string>
+	<key>2 bytes</key>
+	<string>2 bytes</string>
+	<key>3 bytes</key>
+	<string>3 bytes</string>
+	<key>4 bytes</key>
+	<string>4 bytes</string>
+	<key>Stored Value</key>
+	<string>Opgeslagen waarde</string>
+	<key>Previous Value</key>
+	<string>Vorige waarde</string>
+	<key>This Value:</key>
+	<string>Deze waarde:</string>
+	<key>Cheat Description</key>
+	<string>Beschrijving van cheat</string>
+
 </dict>
 </plist>

--- a/OpenEmu/pt.lproj/Localizable.strings
+++ b/OpenEmu/pt.lproj/Localizable.strings
@@ -750,6 +750,8 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Este valor:</string>
 	<key>Cheat Description</key>
 	<string>Descrição da Trapaça</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>A mostrar as primeiras %1$@ de %2$@ correspondências, refine a pesquisa</string>
 
 </dict>
 </plist>

--- a/OpenEmu/pt.lproj/Localizable.strings
+++ b/OpenEmu/pt.lproj/Localizable.strings
@@ -726,12 +726,22 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Tamanho do dado</string>
 	<key>1 byte</key>
 	<string>1 byte</string>
-	<key>2 bytes</key>
-	<string>2 bytes</string>
-	<key>3 bytes</key>
-	<string>3 bytes</string>
-	<key>4 bytes</key>
-	<string>4 bytes</string>
+	<key>%d bytes</key>
+	<string>%d bytes</string>
+	<key>Address</key>
+	<string>Endereço</string>
+	<key>Current</key>
+	<string>Atual</string>
+	<key>Previous</key>
+	<string>Anterior</string>
+	<key>Stored</key>
+	<string>Armazenado</string>
+	<key>Reset</key>
+	<string>Redefinir</string>
+	<key>Address:</key>
+	<string>Endereço:</string>
+	<key>Value (Hex):</key>
+	<string>Valor (Hex):</string>
 	<key>Stored Value</key>
 	<string>Valor armazenado</string>
 	<key>Previous Value</key>

--- a/OpenEmu/pt.lproj/Localizable.strings
+++ b/OpenEmu/pt.lproj/Localizable.strings
@@ -706,5 +706,40 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Sua biblioteca foi movida com sucesso.</string>
 	<key>this guide</key>
 	<string>este manual</string>
+	<key>Add Cheat</key>
+	<string>Adicionar Trapaça</string>
+	<key>Cheat Search…</key>
+	<string>Buscar Trapaças…</string>
+	<key>Cheat Search</key>
+	<string>Buscar Trapaças</string>
+	<key>Store Values</key>
+	<string>Armazenar valores</string>
+	<key>Comparison</key>
+	<string>Comparação</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>Sem sinal (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>Com sinal (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>Hexadecimal</string>
+	<key>Data Size</key>
+	<string>Tamanho do dado</string>
+	<key>1 byte</key>
+	<string>1 byte</string>
+	<key>2 bytes</key>
+	<string>2 bytes</string>
+	<key>3 bytes</key>
+	<string>3 bytes</string>
+	<key>4 bytes</key>
+	<string>4 bytes</string>
+	<key>Stored Value</key>
+	<string>Valor armazenado</string>
+	<key>Previous Value</key>
+	<string>Valor anterior</string>
+	<key>This Value:</key>
+	<string>Este valor:</string>
+	<key>Cheat Description</key>
+	<string>Descrição da Trapaça</string>
+
 </dict>
 </plist>

--- a/OpenEmu/ru.lproj/Localizable.strings
+++ b/OpenEmu/ru.lproj/Localizable.strings
@@ -750,6 +750,8 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Это значение:</string>
 	<key>Cheat Description</key>
 	<string>Описание чит-кода</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>Показаны первые %1$@ из %2$@ совпадений, уточните поиск</string>
 
 </dict>
 </plist>

--- a/OpenEmu/ru.lproj/Localizable.strings
+++ b/OpenEmu/ru.lproj/Localizable.strings
@@ -726,12 +726,22 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Размер данных</string>
 	<key>1 byte</key>
 	<string>1 байт</string>
-	<key>2 bytes</key>
-	<string>2 байта</string>
-	<key>3 bytes</key>
-	<string>3 байта</string>
-	<key>4 bytes</key>
-	<string>4 байта</string>
+	<key>%d bytes</key>
+	<string>%d байт</string>
+	<key>Address</key>
+	<string>Адрес</string>
+	<key>Current</key>
+	<string>Текущее</string>
+	<key>Previous</key>
+	<string>Предыдущее</string>
+	<key>Stored</key>
+	<string>Сохранённое</string>
+	<key>Reset</key>
+	<string>Сбросить</string>
+	<key>Address:</key>
+	<string>Адрес:</string>
+	<key>Value (Hex):</key>
+	<string>Значение (Hex):</string>
 	<key>Stored Value</key>
 	<string>Сохранённое значение</string>
 	<key>Previous Value</key>

--- a/OpenEmu/ru.lproj/Localizable.strings
+++ b/OpenEmu/ru.lproj/Localizable.strings
@@ -706,5 +706,40 @@ You can go to the Controls preferences to check which associations were affected
 	<string>Ваша библиотека успешно перемещена.</string>
 	<key>this guide</key>
 	<string>эту инструкцию</string>
+	<key>Add Cheat</key>
+	<string>Добавить Чит-код</string>
+	<key>Cheat Search…</key>
+	<string>Поиск чит-кодов…</string>
+	<key>Cheat Search</key>
+	<string>Поиск чит-кодов</string>
+	<key>Store Values</key>
+	<string>Сохранить значения</string>
+	<key>Comparison</key>
+	<string>Сравнение</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>Без знака (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>Со знаком (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>Шестнадцатеричный</string>
+	<key>Data Size</key>
+	<string>Размер данных</string>
+	<key>1 byte</key>
+	<string>1 байт</string>
+	<key>2 bytes</key>
+	<string>2 байта</string>
+	<key>3 bytes</key>
+	<string>3 байта</string>
+	<key>4 bytes</key>
+	<string>4 байта</string>
+	<key>Stored Value</key>
+	<string>Сохранённое значение</string>
+	<key>Previous Value</key>
+	<string>Предыдущее значение</string>
+	<key>This Value:</key>
+	<string>Это значение:</string>
+	<key>Cheat Description</key>
+	<string>Описание чит-кода</string>
+
 </dict>
 </plist>

--- a/OpenEmu/tr.lproj/Localizable.strings
+++ b/OpenEmu/tr.lproj/Localizable.strings
@@ -750,6 +750,8 @@ Hangi ilişkilendirmelerin etkilendiğini kontrol etmek için Kontrolcü tercihl
 	<string>Bu değer:</string>
 	<key>Cheat Description</key>
 	<string>Hile Açıklaması </string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>%2$@ eşleşmeden ilk %1$@ tanesi gösteriliyor, aramanızı daraltın</string>
 
 </dict>
 </plist>

--- a/OpenEmu/tr.lproj/Localizable.strings
+++ b/OpenEmu/tr.lproj/Localizable.strings
@@ -726,12 +726,22 @@ Hangi ilişkilendirmelerin etkilendiğini kontrol etmek için Kontrolcü tercihl
 	<string>Veri boyutu</string>
 	<key>1 byte</key>
 	<string>1 bayt</string>
-	<key>2 bytes</key>
-	<string>2 bayt</string>
-	<key>3 bytes</key>
-	<string>3 bayt</string>
-	<key>4 bytes</key>
-	<string>4 bayt</string>
+	<key>%d bytes</key>
+	<string>%d bayt</string>
+	<key>Address</key>
+	<string>Adres</string>
+	<key>Current</key>
+	<string>Mevcut</string>
+	<key>Previous</key>
+	<string>Önceki</string>
+	<key>Stored</key>
+	<string>Kaydedilmiş</string>
+	<key>Reset</key>
+	<string>Sıfırla</string>
+	<key>Address:</key>
+	<string>Adres:</string>
+	<key>Value (Hex):</key>
+	<string>Değer (Hex):</string>
 	<key>Stored Value</key>
 	<string>Saklanan değer</string>
 	<key>Previous Value</key>

--- a/OpenEmu/tr.lproj/Localizable.strings
+++ b/OpenEmu/tr.lproj/Localizable.strings
@@ -706,5 +706,40 @@ Hangi ilişkilendirmelerin etkilendiğini kontrol etmek için Kontrolcü tercihl
 	<string>Kütüphaneniz başarı ile taşındı.</string>
 	<key>this guide</key>
 	<string>Bu rehber</string>
+	<key>Add Cheat</key>
+	<string>Hile ekle</string>
+	<key>Cheat Search…</key>
+	<string>Hile Ara…</string>
+	<key>Cheat Search</key>
+	<string>Hile Ara</string>
+	<key>Store Values</key>
+	<string>Değerleri sakla</string>
+	<key>Comparison</key>
+	<string>Karşılaştırma</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>İşaretsiz (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>İşaretli (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>Onaltılık</string>
+	<key>Data Size</key>
+	<string>Veri boyutu</string>
+	<key>1 byte</key>
+	<string>1 bayt</string>
+	<key>2 bytes</key>
+	<string>2 bayt</string>
+	<key>3 bytes</key>
+	<string>3 bayt</string>
+	<key>4 bytes</key>
+	<string>4 bayt</string>
+	<key>Stored Value</key>
+	<string>Saklanan değer</string>
+	<key>Previous Value</key>
+	<string>Önceki değer</string>
+	<key>This Value:</key>
+	<string>Bu değer:</string>
+	<key>Cheat Description</key>
+	<string>Hile Açıklaması </string>
+
 </dict>
 </plist>

--- a/OpenEmu/zh-Hans.lproj/Localizable.strings
+++ b/OpenEmu/zh-Hans.lproj/Localizable.strings
@@ -749,6 +749,8 @@ You can go to the Controls preferences to check which associations were affected
 	<string>此值:</string>
 	<key>Cheat Description</key>
 	<string>金手指描述</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>显示 %2$@ 个匹配项中的前 %1$@ 个，请缩小搜索范围</string>
 
 </dict>
 </plist>

--- a/OpenEmu/zh-Hans.lproj/Localizable.strings
+++ b/OpenEmu/zh-Hans.lproj/Localizable.strings
@@ -725,12 +725,22 @@ You can go to the Controls preferences to check which associations were affected
 	<string>数据大小</string>
 	<key>1 byte</key>
 	<string>1字节</string>
-	<key>2 bytes</key>
-	<string>2字节</string>
-	<key>3 bytes</key>
-	<string>3字节</string>
-	<key>4 bytes</key>
-	<string>4字节</string>
+	<key>%d bytes</key>
+	<string>%d 字节</string>
+	<key>Address</key>
+	<string>地址</string>
+	<key>Current</key>
+	<string>当前值</string>
+	<key>Previous</key>
+	<string>上次值</string>
+	<key>Stored</key>
+	<string>存储值</string>
+	<key>Reset</key>
+	<string>重置</string>
+	<key>Address:</key>
+	<string>地址:</string>
+	<key>Value (Hex):</key>
+	<string>数值 (十六进制):</string>
 	<key>Stored Value</key>
 	<string>已存储值</string>
 	<key>Previous Value</key>

--- a/OpenEmu/zh-Hans.lproj/Localizable.strings
+++ b/OpenEmu/zh-Hans.lproj/Localizable.strings
@@ -705,5 +705,40 @@ You can go to the Controls preferences to check which associations were affected
 	<string>移动游戏库成功。</string>
 	<key>this guide</key>
 	<string>本指南</string>
+	<key>Add Cheat</key>
+	<string>添加金手指</string>
+	<key>Cheat Search…</key>
+	<string>搜索金手指…</string>
+	<key>Cheat Search</key>
+	<string>搜索金手指</string>
+	<key>Store Values</key>
+	<string>存储值</string>
+	<key>Comparison</key>
+	<string>比较</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>无符号 (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>有符号 (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>十六进制</string>
+	<key>Data Size</key>
+	<string>数据大小</string>
+	<key>1 byte</key>
+	<string>1字节</string>
+	<key>2 bytes</key>
+	<string>2字节</string>
+	<key>3 bytes</key>
+	<string>3字节</string>
+	<key>4 bytes</key>
+	<string>4字节</string>
+	<key>Stored Value</key>
+	<string>已存储值</string>
+	<key>Previous Value</key>
+	<string>前一个值</string>
+	<key>This Value:</key>
+	<string>此值:</string>
+	<key>Cheat Description</key>
+	<string>金手指描述</string>
+
 </dict>
 </plist>

--- a/OpenEmu/zh-Hant.lproj/Localizable.strings
+++ b/OpenEmu/zh-Hant.lproj/Localizable.strings
@@ -749,6 +749,8 @@ You can go to the Controls preferences to check which associations were affected
 	<string>此值:</string>
 	<key>Cheat Description</key>
 	<string>金手指描述</string>
+	<key>Showing first %1$@ of %2$@ matches, narrow your search</key>
+	<string>顯示 %2$@ 個相符項目中的前 %1$@ 個，請縮小搜尋範圍</string>
 
 </dict>
 </plist>

--- a/OpenEmu/zh-Hant.lproj/Localizable.strings
+++ b/OpenEmu/zh-Hant.lproj/Localizable.strings
@@ -705,5 +705,40 @@ You can go to the Controls preferences to check which associations were affected
 	<string>成功移動遊戲庫。</string>
 	<key>this guide</key>
 	<string>本指南</string>
+	<key>Add Cheat</key>
+	<string>新增金手指</string>
+	<key>Cheat Search…</key>
+	<string>搜尋金手指…</string>
+	<key>Cheat Search</key>
+	<string>搜尋金手指</string>
+	<key>Store Values</key>
+	<string>儲存值</string>
+	<key>Comparison</key>
+	<string>比較</string>
+	<key>Unsigned (&gt;=0)</key>
+	<string>無符號 (&gt;=0)</string>
+	<key>Signed (+/-)</key>
+	<string>有符號 (+/-)</string>
+	<key>Hexadecimal</key>
+	<string>十六進位</string>
+	<key>Data Size</key>
+	<string>資料大小</string>
+	<key>1 byte</key>
+	<string>1位元組</string>
+	<key>2 bytes</key>
+	<string>2位元組</string>
+	<key>3 bytes</key>
+	<string>3位元組</string>
+	<key>4 bytes</key>
+	<string>4位元組</string>
+	<key>Stored Value</key>
+	<string>已儲存值</string>
+	<key>Previous Value</key>
+	<string>前一個值</string>
+	<key>This Value:</key>
+	<string>此值:</string>
+	<key>Cheat Description</key>
+	<string>金手指描述</string>
+
 </dict>
 </plist>

--- a/OpenEmu/zh-Hant.lproj/Localizable.strings
+++ b/OpenEmu/zh-Hant.lproj/Localizable.strings
@@ -725,12 +725,22 @@ You can go to the Controls preferences to check which associations were affected
 	<string>資料大小</string>
 	<key>1 byte</key>
 	<string>1位元組</string>
-	<key>2 bytes</key>
-	<string>2位元組</string>
-	<key>3 bytes</key>
-	<string>3位元組</string>
-	<key>4 bytes</key>
-	<string>4位元組</string>
+	<key>%d bytes</key>
+	<string>%d 位元組</string>
+	<key>Address</key>
+	<string>位址</string>
+	<key>Current</key>
+	<string>目前值</string>
+	<key>Previous</key>
+	<string>上次值</string>
+	<key>Stored</key>
+	<string>儲存值</string>
+	<key>Reset</key>
+	<string>重置</string>
+	<key>Address:</key>
+	<string>位址:</string>
+	<key>Value (Hex):</key>
+	<string>數值 (十六進位):</string>
 	<key>Stored Value</key>
 	<string>已儲存值</string>
 	<key>Previous Value</key>

--- a/OpenEmuKit/Source/GameCoreManager.swift
+++ b/OpenEmuKit/Source/GameCoreManager.swift
@@ -130,9 +130,9 @@ extension GameCoreManager: OEGameCoreHelper {
             let regions: [OEMemoryRegionDescriptor] = dicts.compactMap { dict in
                 guard let name = dict["name"] as? String,
                       let address = dict["address"] as? UInt32,
+                      let addressBytes = dict["addressBytes"] as? UInt8,
                       let data = dict["data"] as? Data
                 else { return nil }
-                let addressBytes = dict["addressBytes"] as? UInt8 ?? 2
                 let minDataBytes = dict["minDataBytes"] as? UInt8 ?? 1
                 return OEMemoryRegionDescriptor(name: name, address: address, addressBytes: addressBytes, minDataBytes: minDataBytes, data: data)
             }

--- a/OpenEmuKit/Source/GameCoreManager.swift
+++ b/OpenEmuKit/Source/GameCoreManager.swift
@@ -116,7 +116,30 @@ extension GameCoreManager: OEGameCoreHelper {
     public func setCheat(_ cheatCode: String, withType type: String, enabled: Bool) {
         gameCoreHelper?.setCheat(cheatCode, withType: type, enabled: enabled)
     }
-    
+
+    public func readableMemoryRegions(completionHandler block: @escaping ([[String: Any]]) -> Void) {
+        gameCoreHelper!.readableMemoryRegions { dicts in
+            DispatchQueue.main.async {
+                block(dicts)
+            }
+        }
+    }
+
+    public func readableMemoryRegionDescriptors(completionHandler block: @escaping ([OEMemoryRegionDescriptor]) -> Void) {
+        readableMemoryRegions { dicts in
+            let regions: [OEMemoryRegionDescriptor] = dicts.compactMap { dict in
+                guard let name = dict["name"] as? String,
+                      let address = dict["address"] as? UInt32,
+                      let data = dict["data"] as? Data
+                else { return nil }
+                let addressBytes = dict["addressBytes"] as? UInt8 ?? 2
+                let minDataBytes = dict["minDataBytes"] as? UInt8 ?? 1
+                return OEMemoryRegionDescriptor(name: name, address: address, addressBytes: addressBytes, minDataBytes: minDataBytes, data: data)
+            }
+            block(regions)
+        }
+    }
+
     public func setDisc(_ discNumber: UInt) {
         gameCoreHelper?.setDisc(discNumber)
     }

--- a/OpenEmuKit/Source/OECorePlugin.swift
+++ b/OpenEmuKit/Source/OECorePlugin.swift
@@ -259,7 +259,13 @@ public extension OECorePlugin {
         let options = coreOptions[systemIdentifier]
         return options?[OEGameCoreSupportsCheatCodeKey] as? Bool ?? false
     }
-    
+
+    func supportsCheatSearch(forSystemIdentifier systemIdentifier: String) -> Bool {
+        guard supportsCheatCode(forSystemIdentifier: systemIdentifier) else { return false }
+        let options = coreOptions[systemIdentifier]
+        return options?[OEGameCoreSupportsCheatSearchKey] as? Bool ?? false
+    }
+
     func hasGlitches(forSystemIdentifier systemIdentifier: String) -> Bool {
         let options = coreOptions[systemIdentifier]
         return options?[OEGameCoreHasGlitchesKey] as? Bool ?? false

--- a/OpenEmuKit/Source/OEGameCoreHelper.swift
+++ b/OpenEmuKit/Source/OEGameCoreHelper.swift
@@ -78,6 +78,7 @@ import AudioToolbox
     func saveStateToFile(at fileURL: URL, completionHandler block: @escaping (Bool, Error?) -> Void)
     func loadStateFromFile(at fileURL: URL, completionHandler block: @escaping (Bool, Error?) -> Void)
     func setCheat(_ cheatCode: String, withType type: String, enabled: Bool)
+    func readableMemoryRegions(completionHandler block: @escaping ([[String: Any]]) -> Void)
     func setDisc(_ discNumber: UInt)
     func changeDisplay(withMode displayMode: String)
     func insertFile(at url: URL, completionHandler block: @escaping (Bool, Error?) -> Void)

--- a/OpenEmuKit/Source/OEXPCGameCoreManager.swift
+++ b/OpenEmuKit/Source/OEXPCGameCoreManager.swift
@@ -95,6 +95,14 @@ import OpenEmuKitPrivate
                             argumentIndex: 0,
                             ofReply: false)
 
+            // cheat search
+            let memoryRegionClasses: NSSet = [NSDictionary.self, NSArray.self, NSString.self, NSNumber.self, NSData.self]
+            // swiftlint:disable:next force_cast
+            intf.setClasses(memoryRegionClasses as! Set<AnyHashable>,
+                            for: #selector(OEGameCoreHelper.readableMemoryRegions(completionHandler:)),
+                            argumentIndex: 0,
+                            ofReply: true)
+
             cn.remoteObjectInterface = intf
             cn.resume()
 

--- a/OpenEmuKit/Source/OpenEmuHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuHelperApp.swift
@@ -660,7 +660,23 @@ extension OSLog {
             self.gameCore.setCheat(cheatCode, setType: type, setEnabled: enabled)
         }
     }
-    
+
+    public func readableMemoryRegions(completionHandler block: @escaping ([[String: Any]]) -> Void) {
+        gameCore.perform {
+            let regions = self.gameCore.readableMemoryRegions()
+            let dicts: [[String: Any]] = regions.map { region in
+                [
+                    "name": region.name,
+                    "address": region.address,
+                    "addressBytes": region.addressBytes,
+                    "minDataBytes": region.minDataBytes,
+                    "data": region.data,
+                ]
+            }
+            block(dicts)
+        }
+    }
+
     public func setDisc(_ discNumber: UInt) {
         gameCore.perform {
             self.gameCore.setDisc(discNumber)

--- a/OpenEmuKit/Source/OpenEmuXPCHelperApp.swift
+++ b/OpenEmuKit/Source/OpenEmuXPCHelperApp.swift
@@ -115,6 +115,14 @@ internal import os.log
                         argumentIndex: 0,
                         ofReply: false)
         
+        // cheat search
+        let memoryRegionClasses: NSSet = [NSDictionary.self, NSArray.self, NSString.self, NSNumber.self, NSData.self]
+        // swiftlint:disable:next force_cast
+        intf.setClasses(memoryRegionClasses as! Set<AnyHashable>,
+                        for: #selector(OEXPCGameCoreHelper.readableMemoryRegions(completionHandler:)),
+                        argumentIndex: 0,
+                        ofReply: true)
+        
         gameCoreConnection = newConnection
         
         newConnection.exportedInterface = intf

--- a/SNES9x/Info.plist
+++ b/SNES9x/Info.plist
@@ -36,6 +36,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>
 			<true/>
 			<key>OEGameCoreSupportsRewinding</key>

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -1114,6 +1114,7 @@ void S9xParsePortConfig(ConfigFile&, int)
 
 - (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
 {
+    if (Memory.CalculatedSize == 0) return @[];
     NSData *data = [NSData dataWithBytes:Memory.RAM length:0x20000];
     OEMemoryRegionDescriptor *wram = [OEMemoryRegionDescriptor descriptorWithName:@"WRAM"
                                                                           address:0x7E0000

--- a/SNES9x/SNESGameCore.mm
+++ b/SNES9x/SNESGameCore.mm
@@ -27,6 +27,7 @@
 
 #import "SNESGameCore.h"
 #import <OpenEmuBase/OERingBuffer.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
 #import <OpenGL/gl.h>
 
 #include "snes9x.h"
@@ -1109,6 +1110,16 @@ void S9xParseArg(char**, int&, int)
 
 void S9xParsePortConfig(ConfigFile&, int)
 {
+}
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+    NSData *data = [NSData dataWithBytes:Memory.RAM length:0x20000];
+    OEMemoryRegionDescriptor *wram = [OEMemoryRegionDescriptor descriptorWithName:@"WRAM"
+                                                                          address:0x7E0000
+                                                                     addressBytes:3
+                                                                             data:data];
+    return @[wram];
 }
 
 @end

--- a/Stella/Info.plist
+++ b/Stella/Info.plist
@@ -32,6 +32,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsDisplayModeChange</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatCode</key>
+			<true/>
 			<key>OEGameCoreSupportsRewinding</key>
 			<true/>
 		</dict>

--- a/Stella/Info.plist
+++ b/Stella/Info.plist
@@ -34,6 +34,8 @@
 			<true/>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsRewinding</key>
 			<true/>
 		</dict>

--- a/Stella/StellaGameCore.mm
+++ b/Stella/StellaGameCore.mm
@@ -27,6 +27,7 @@
 
 #import "StellaGameCore.h"
 #import <OpenEmuBase/OERingBuffer.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
 #import "OE2600SystemResponderClient.h"
 #import <OpenGL/gl.h>
 
@@ -528,6 +529,20 @@ void stellaOESetPalette(const uInt32 *palette)
         _cheatList[code] = @YES;
     else
         [_cheatList removeObjectForKey:code];
+}
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+    uint8_t ram[128];
+    for (int i = 0; i < 128; i++)
+        ram[i] = console->system().peek((uInt16)(0x80 + i));
+
+    NSData *data = [NSData dataWithBytes:ram length:128];
+    OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor descriptorWithName:@"RAM"
+                                                                              address:0x80
+                                                                         addressBytes:1
+                                                                                 data:data];
+    return @[descriptor];
 }
 
 @end

--- a/Stella/StellaGameCore.mm
+++ b/Stella/StellaGameCore.mm
@@ -178,8 +178,8 @@ void stellaOESetPalette(const uInt32 *palette)
             NSRange colonRange = [singleCode rangeOfString:@":"];
             if (colonRange.location != NSNotFound) {
                 unsigned int addr = 0, val = 0;
-                [[NSScanner scannerWithString:[singleCode substringToIndex:colonRange.location]] scanHexInt:&addr];
-                [[NSScanner scannerWithString:[singleCode substringFromIndex:colonRange.location + 1]] scanHexInt:&val];
+                if (![[NSScanner scannerWithString:[singleCode substringToIndex:colonRange.location]] scanHexInt:&addr]) continue;
+                if (![[NSScanner scannerWithString:[singleCode substringFromIndex:colonRange.location + 1]] scanHexInt:&val]) continue;
                 console->system().poke((uInt16)addr, (uInt8)val);
             }
         }

--- a/Stella/StellaGameCore.mm
+++ b/Stella/StellaGameCore.mm
@@ -533,6 +533,7 @@ void stellaOESetPalette(const uInt32 *palette)
 
 - (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
 {
+    if (!console) return @[];
     uint8_t ram[128];
     for (int i = 0; i < 128; i++)
         ram[i] = console->system().peek((uInt16)(0x80 + i));

--- a/Stella/StellaGameCore.mm
+++ b/Stella/StellaGameCore.mm
@@ -73,6 +73,7 @@ void stellaOESetPalette(const uInt32 *palette)
     int16_t *_sampleBuffer;
     int _videoWidth, _videoHeight;
     NSMutableArray <NSMutableDictionary <NSString *, id> *> *_availableDisplayModes;
+    NSMutableDictionary<NSString *, NSNumber *> *_cheatList;
 }
 
 - (void)loadDisplayModeOptions;
@@ -168,6 +169,20 @@ void stellaOESetPalette(const uInt32 *palette)
 
     TIA &tia = console->tia();
     tia.update();
+
+    for (NSString *key in _cheatList) {
+        if (![_cheatList[key] boolValue]) continue;
+        NSArray<NSString *> *codes = [key componentsSeparatedByString:@"+"];
+        for (NSString *singleCode in codes) {
+            NSRange colonRange = [singleCode rangeOfString:@":"];
+            if (colonRange.location != NSNotFound) {
+                unsigned int addr = 0, val = 0;
+                [[NSScanner scannerWithString:[singleCode substringToIndex:colonRange.location]] scanHexInt:&addr];
+                [[NSScanner scannerWithString:[singleCode substringFromIndex:colonRange.location + 1]] scanHexInt:&val];
+                console->system().poke((uInt16)addr, (uInt8)val);
+            }
+        }
+    }
 
     // Video
     _videoWidth = tia.width();
@@ -499,6 +514,20 @@ void stellaOESetPalette(const uInt32 *palette)
     if (lastFormat && ![lastFormat isEqualToString:@"Auto"]) {
         [self changeDisplayWithMode:lastFormat];
     }
+}
+
+- (void)setCheat:(NSString *)code setType:(NSString *)type setEnabled:(BOOL)enabled
+{
+    if (!_cheatList)
+        _cheatList = [NSMutableDictionary dictionary];
+
+    code = [code stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    code = [code stringByReplacingOccurrencesOfString:@" " withString:@""];
+
+    if (enabled)
+        _cheatList[code] = @YES;
+    else
+        [_cheatList removeObjectForKey:code];
 }
 
 @end

--- a/mGBA/Info.plist
+++ b/mGBA/Info.plist
@@ -32,6 +32,8 @@
 			<integer>0</integer>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
+			<key>OEGameCoreSupportsCheatSearch</key>
+			<true/>
 			<key>OEGameCoreSupportsRetroAchievements</key>
 			<true/>
 			<key>OEGameCoreSupportsRewinding</key>

--- a/mGBA/src/platform/openemu/mGBAGameCore.m
+++ b/mGBA/src/platform/openemu/mGBAGameCore.m
@@ -40,6 +40,7 @@
 
 #import <OpenEmuBase/OEGameCoreController.h>
 #import <OpenEmuBase/OERingBuffer.h>
+#import <OpenEmuBase/OEMemoryRegionDescriptor.h>
 #import "OEGBASystemResponderClient.h"
 #import <OpenGL/gl.h>
 
@@ -402,24 +403,40 @@ const int GBAMap[] = {
 		cheatSet->copyProperties(cheatSet, *mCheatSetsGetPointer(&cheats->cheats, size - 1));
 	}
 	int codeType = GBA_CHEAT_AUTODETECT;
-	// NOTE: This is deprecated and was only meant to test cheats with the UI using cheats-database.xml
-	// Will be replaced with a sqlite database in the future.
-//    if ([type isEqual:@"GameShark"]) {
-//        codeType = GBA_CHEAT_GAMESHARK;
-//    } else if ([type isEqual:@"Action Replay"]) {
-//        codeType = GBA_CHEAT_PRO_ACTION_REPLAY;
-//    }
 	NSArray *codeSet = [code componentsSeparatedByString:@"+"];
 	for (id c in codeSet) {
-//        if ([c length] == 12)
-//            codeType = GBA_CHEAT_CODEBREAKER;
-//        if ([c length] == 16) // default to GS/AR v1/v2 code (can't determine GS/AR v1/v2 vs AR v3 because same length)
-//            codeType = GBA_CHEAT_GAMESHARK;
 		mCheatAddLine(cheatSet, [c UTF8String], codeType);
 	}
 	cheatSet->enabled = enabled;
 	[cheatSets setObject:[NSValue valueWithPointer:cheatSet] forKey:codeId];
 	mCheatAddSet(cheats, cheatSet);
 }
+
+- (NSArray<OEMemoryRegionDescriptor *> *)readableMemoryRegions
+{
+	const struct mCoreMemoryBlock* blocks = NULL;
+	size_t count = core->listMemoryBlocks(core, &blocks);
+	NSMutableArray *regions = [NSMutableArray arrayWithCapacity:count];
+	for (size_t i = 0; i < count; i++) {
+		if (strcmp(blocks[i].shortName, "IWRAM") != 0 &&
+		    strcmp(blocks[i].shortName, "EWRAM") != 0) {
+			continue;
+		}
+		size_t size = 0;
+		void* memory = core->getMemoryBlock(core, blocks[i].id, &size);
+		if (memory && size > 0) {
+			NSData *data = [NSData dataWithBytes:memory length:size];
+			NSString *name = [NSString stringWithUTF8String:blocks[i].shortName];
+			OEMemoryRegionDescriptor *descriptor = [OEMemoryRegionDescriptor
+			    descriptorWithName:name
+			              address:blocks[i].start
+			         addressBytes:4
+			                 data:data];
+			[regions addObject:descriptor];
+		}
+	}
+	return regions;
+}
+
 @end
 


### PR DESCRIPTION
## What does this PR do?

I implemented a **Cheat Search** feature, inspired by the one from ZNES.

As part of it, I also added cheat support for **PSX** (Mednafen) and **Atari 2600** (Stella).

<img width="1225" height="711" alt="Screenshot 2026-08-07 at 00 57 32" src="https://github.com/user-attachments/assets/4a388654-560f-4d86-aae5-fae52afdb186" />

<img width="1064" height="684" alt="Screenshot 2026-08-07 at 19 25 48" src="https://github.com/user-attachments/assets/40e458ef-7e69-4d87-a4cc-245e47cd8373" />


## What did you test?

I tested one game per platform, except for N64 (Mupen64Plus) and GB/GBC (Gambatte). I also did not test the localisation.

It would be really great if more people can test all of these modules more deeply.

## Which cores or systems are affected?

OpenEmu / OpenEmu-SDK / OpenEmuKit

mGBA
SNES9x
BSNES
FCEU
Nestopia
GenesisPlus
Gambatte
CrabEmu
DeSmuME
Mupen64Plus
Stella
Mednafen

## Did you use AI tools?

I used AI to understand the structure of the project, to automate build/sign/deploy process, to investigate memory access on each core module, and to generate the UI (layout, interaction, localization)

## Linked issues

<!-- Use "Fixes #N" to auto-close an issue on merge, or "Related to #N" to soft-link -->

Fixes #654 
Related to #645 
Related to #653 
Related to #633 
Fixes #272 

## PR checklist

- [X] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [X] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [X] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [X] No build logs, binaries, or credentials committed
- [X] Copyright headers preserved on all modified files
- [X] New files (if any) include the BSD 2-Clause license header
