### PR TITLE
fix: recognize Sonic & Knuckles lock-on ROM as Genesis BIOS file

### DIFF
--- a/GenesisPlus/Info.plist
+++ b/GenesisPlus/Info.plist
@@ -101,6 +101,21 @@
 			<true/>
 			<key>OEGameCoreSupportsRewinding</key>
 			<true/>
+			<key>OERequiredFiles</key>
+			<array>
+				<dict>
+					<key>Description</key>
+					<string>Sonic &amp; Knuckles (Lock-on) UPMEM Chip</string>
+					<key>MD5</key>
+					<string>b4e76e416b887f4e7413ba76fa735f16</string>
+					<key>Name</key>
+					<string>Sonic &amp; Knuckles (World) (Lock-on).bin</string>
+					<key>Size</key>
+					<integer>262144</integer>
+					<key>Optional</key>
+					<true/>
+				</dict>
+			</array>
 		</dict>
 		<key>openemu.system.sg1000</key>
 		<dict>


### PR DESCRIPTION
## What does this PR do?

Adds an optional `OERequiredFiles` entry to the Genesis/Mega Drive core (`GenesisPlus/Info.plist`) for the Sonic & Knuckles UPMEM lock-on chip dump, so drag-and-drop import recognizes it and copies it into the BIOS folder automatically instead of importing it as a regular game ROM.

## What did you test?

Dragged a correctly-hashed `Sonic & Knuckles (World) (Lock-on).bin` onto the debug build — it was recognized as a BIOS file. Then loaded Sonic the Hedgehog 2, locked on to Sonic & Knuckles, and confirmed it works.

## Which cores or systems are affected?

Genesis Plus GX (GenesisPlus) — Sega Genesis / Mega Drive system only. Sega CD BIOS import is unaffected (untouched entries).

## Did you use AI tools?

Used Claude to investigate the core's BIOS-matching mechanism, draft the fix, and run an adversarial review pass; reviewed and tested it myself.

## Linked issues

Fixes #636

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 659 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

<!-- Add any PR-specific setup here (BIOS files, permissions to revoke, specific ROM to test with). -->

This PR touches the GenesisPlus core:

```bash
./Scripts/install-core.sh GenesisPlus
./Scripts/launch-debug.sh
```

To test: drag a copy of `Sonic & Knuckles (World) (Lock-on).bin` (MD5 `b4e76e416b887f4e7413ba76fa735f16`) onto OpenEmu, confirm it's imported as a BIOS file, then lock Sonic the Hedgehog 2 onto Sonic & Knuckles and confirm it launches instead of hanging on a black screen.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header

---

## Adversarial review

An adversarial review flagged one point worth surfacing rather than a code change:

- **Single-hash match risk (note, not fixed):** the new entry matches only one exact MD5. If a different (but still "valid") dump of this file circulates, import would silently fail for that copy with no error. Unlike the three Sega CD BIOS entries — which cover three genuinely distinct official firmware releases (EU/US/JP) — this UPMEM chip dump isn't a regional/official release with known alternate revisions; it's a single fan-extracted file that circulates as one canonical dump, and the MD5 here was verified directly against a real, currently-working copy (not guessed), confirmed via a live drag-and-drop + in-game test. No evidence of a legitimate alternate hash exists to add. If future reports surface a different valid hash for this same file, a second sibling `OERequiredFiles` entry can be added the same way the CD BIOS entries already do for their three variants.
- Reviewer also noted `openemu.system.sg` doesn't set `OEGameCoreRequiresFiles`, so the missing-BIOS alert never fires for this entry. That's intentional: the file is `Optional: true` and lock-on is opt-in, so no alert should ever block normal Genesis play — only drag-and-drop auto-detection will place this file.