### PR TITLE
fix: persist battery RAM for RetroArch-bridged libretro cores

### DIFF
--- a/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
+++ b/OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m
@@ -435,12 +435,19 @@ static OELibretroSystemPolicy OELibretroSystemPolicyForSystemID(NSString *system
     void (*_retro_reset)(void);
     bool (*_retro_load_game)(const struct retro_game_info *game);
     void (*_retro_unload_game)(void);
-    
+
     // Serialization
     size_t (*_retro_serialize_size)(void);
     bool (*_retro_serialize)(void *data, size_t size);
     bool (*_retro_unserialize)(const void *data, size_t size);
-    
+
+    // Battery RAM (SRAM) — the frontend, not the core, is responsible for
+    // pulling this out of the core and persisting it to disk. See
+    // -loadFileAtPath: and -stopEmulation.
+    void   *(*_retro_get_memory_data)(unsigned id);
+    size_t  (*_retro_get_memory_size)(unsigned id);
+    NSURL  *_batterySaveFileURL;
+
     struct retro_system_av_info _avInfo;
     struct retro_hw_render_callback _hw_callback;
 @public
@@ -1366,6 +1373,14 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
 
     self.coreBundle = [[self owner] bundle];
 
+    // Recompute savesPath now that -owner is available. -init runs before
+    // the XPC helper assigns -owner, so batterySavesDirectoryPath (which
+    // reads -owner) returns nil at that point — the -init-time value is a
+    // placeholder only, never something to load-bearing code should trust.
+    self.savesPath = [self batterySavesDirectoryPath];
+    free(_savesPathCStr);
+    _savesPathCStr = self.savesPath ? strdup([self.savesPath UTF8String]) : NULL;
+
     // Fallback: if owner didn't provide a bundle, scan all loaded bundles
     // for one that declares OELibretroCoreTranslator as its game core class.
     if (!self.coreBundle) {
@@ -1453,7 +1468,12 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
     RESOLVE(retro_serialize_size);
     RESOLVE(retro_serialize);
     RESOLVE(retro_unserialize);
-    
+
+    // Optional: battery RAM access. Most cores implement this even though
+    // it's not in the "essential" set checked below.
+    RESOLVE(retro_get_memory_data);
+    RESOLVE(retro_get_memory_size);
+
     // Safety check for absolute minimum required to function
     if (!_retro_init || !_retro_run || !_retro_load_game) {
         if (error) {
@@ -1520,13 +1540,38 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
 
         NSLog(@"[OELibretro] !!! CRITICAL LOAD FAILURE: %@", errorMsg);
         if (error) {
-            *error = [NSError errorWithDomain:OEGameCoreErrorDomain 
-                                         code:OEGameCoreCouldNotLoadROMError 
+            *error = [NSError errorWithDomain:OEGameCoreErrorDomain
+                                         code:OEGameCoreCouldNotLoadROMError
                                      userInfo:@{NSLocalizedDescriptionKey: errorMsg}];
         }
         return NO;
     }
-    
+
+    // Battery RAM restore. The libretro spec leaves persistence to the
+    // frontend: read the save file (if any) and copy it into the core's
+    // SAVE_RAM buffer now that the game is loaded and that buffer exists.
+    // Same directory/filename convention as OpenEmu's native cores (e.g.
+    // GenPlusGameCore) so a ROM's save carries over between the native and
+    // RetroArch-bridged builds of the same core.
+    if (self.savesPath) {
+        NSString *extensionlessFilename = [[path lastPathComponent] stringByDeletingPathExtension];
+        NSURL *batterySavesDirectory = [NSURL fileURLWithPath:self.savesPath];
+        [[NSFileManager defaultManager] createDirectoryAtURL:batterySavesDirectory withIntermediateDirectories:YES attributes:nil error:nil];
+        _batterySaveFileURL = [batterySavesDirectory URLByAppendingPathComponent:[extensionlessFilename stringByAppendingPathExtension:@"sav"]];
+
+        if (_retro_get_memory_data && _retro_get_memory_size) {
+            void *sramBuffer = _retro_get_memory_data(RETRO_MEMORY_SAVE_RAM);
+            size_t sramSize = _retro_get_memory_size(RETRO_MEMORY_SAVE_RAM);
+            if (sramBuffer && sramSize > 0) {
+                NSData *saveData = [NSData dataWithContentsOfURL:_batterySaveFileURL];
+                if (saveData) {
+                    memcpy(sramBuffer, [saveData bytes], MIN(sramSize, [saveData length]));
+                    NSLog(@"[OELibretro] Restored battery save (%zu bytes) from %@", (size_t)[saveData length], _batterySaveFileURL);
+                }
+            }
+        }
+    }
+
     // Core is loaded — resolve serialization state size now.
     // Spec: cores may only know their true state size after loading content.
     if (_retro_serialize_size) {
@@ -1559,6 +1604,24 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
 
 - (void)stopEmulation {
     [super stopEmulation];
+
+    // Battery RAM persist. Must happen before retro_unload_game/retro_deinit
+    // tear down the core — the SAVE_RAM buffer they return is only valid
+    // while the core is loaded.
+    if (_coreHandle && _batterySaveFileURL && _retro_get_memory_data && _retro_get_memory_size) {
+        void *sramBuffer = _retro_get_memory_data(RETRO_MEMORY_SAVE_RAM);
+        size_t sramSize = _retro_get_memory_size(RETRO_MEMORY_SAVE_RAM);
+        if (sramBuffer && sramSize > 0) {
+            NSData *saveData = [NSData dataWithBytes:sramBuffer length:sramSize];
+            NSError *writeError = nil;
+            if ([saveData writeToURL:_batterySaveFileURL options:NSDataWritingAtomic error:&writeError]) {
+                NSLog(@"[OELibretro] Saved battery save (%zu bytes) to %@", sramSize, _batterySaveFileURL);
+            } else {
+                NSLog(@"[OELibretro] Error writing battery save file: %@", writeError);
+            }
+        }
+    }
+
     // Nil _current BEFORE dlclose so any callbacks that fire during shutdown
     // see nil and return early (prevents use-after-free in C callbacks).
     _current = nil;
@@ -1568,6 +1631,7 @@ static void* bridge_dlsym(void *handle, const char *symbol) {
         dlclose(_coreHandle);
         _coreHandle = NULL;
     }
+    _batterySaveFileURL = nil;
 }
 
 - (void)executeFrame {

--- a/OpenEmu-SDK/OpenEmuBase/libretro.h
+++ b/OpenEmu-SDK/OpenEmuBase/libretro.h
@@ -90,6 +90,12 @@ extern "C" {
 // ── Sentinel for HW-rendered frames ──────────────────────────────────
 #define RETRO_HW_FRAME_BUFFER_VALID ((void*)-1)
 
+// ── Memory IDs (retro_get_memory_data/size) ──────────────────────────
+#define RETRO_MEMORY_SAVE_RAM    0
+#define RETRO_MEMORY_RTC         1
+#define RETRO_MEMORY_SYSTEM_RAM  2
+#define RETRO_MEMORY_VIDEO_RAM   3
+
 // ── Input devices / IDs ──────────────────────────────────────────────
 #define RETRO_DEVICE_JOYPAD              1
 #define RETRO_DEVICE_ANALOG              2


### PR DESCRIPTION
## What does this PR do?

The libretro bridge (`OELibretroCoreTranslator`) handled save states but never called `retro_get_memory_data`/`retro_get_memory_size` for `RETRO_MEMORY_SAVE_RAM`, so any RetroArch-wrapped core (e.g. RetroArch Genesis Plus GX) silently lost in-game battery saves every time it started a fresh session. This adds battery RAM restore-on-load and persist-on-stop to the shared libretro host, so it covers every RetroArch-bridged core at once — using the same save directory/filename convention (`<rom>.sav` in `batterySavesDirectoryPath`) as OpenEmu's native cores.

Also fixes a crash uncovered while building this: `savesPath` was being read at `-init` time, before `-owner` is assigned by the XPC helper, so it was silently nil — `NSURL fileURLWithPath:` throws on nil, which aborted the helper process the moment any RetroArch core tried to load. Fixed by recomputing `savesPath` inside `-loadFileAtPath:` once `-owner` is actually available, with a nil-guard as a backstop.

## What did you test?

Tested with Sonic The Hedgehog 3 (USA) on the RetroArch Genesis Plus GX core, following the original repro steps:

* Fresh load (no save state) → played → quit: confirmed `.sav` file written to `Genesis Plus GX-RetroArch/Battery Saves/Sonic The Hedgehog 3 (USA).sav` (604 bytes), and the "Saved battery save" log line fired.
* Reloaded the same ROM without a save state: confirmed the "Restored battery save" log line fired with the same byte count, and the save showed up in-game on the continue/save-slot screen.
* Sanity-checked with Sonic 2 first — correctly showed zero save activity, since the original Sonic 2 cartridge has no battery chip (expected, not a bug).
* `./Scripts/verify.sh --launch`: build, static analyzer, plist lint, and codesign checks all pass.

## Which cores or systems are affected?

The shared libretro/RetroArch bridge (`OpenEmu-SDK/OpenEmuBase/OELibretroCoreTranslator.m`), which affects every RetroArch-wrapped core, not just Genesis Plus GX.

## Did you use AI tools?

Used Claude to research the root cause, implement the fix, and debug a crash that surfaced during testing. Reviewed and tested myself.

## Linked issues

Fixes nickybmon/OpenEmu-Silicon#666

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

Requires a local RetroArch install with the Genesis Plus GX core, plus a Genesis ROM with battery saves (Sonic The Hedgehog 3 was used for testing).

---

## PR checklist

- [X] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [X] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [X] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [X] No build logs, binaries, or credentials committed
- [X] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header