### PR TITLE
fix: skip controllers with no readable controls instead of crashing

### DIFF
--- a/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
+++ b/OpenEmu-SDK/OpenEmu-SDK.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		0572A3FF287781BA00AC32F8 /* OEGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0572A3FE287781BA00AC32F8 /* OEGeometry.swift */; };
 		05F2F90824EA029900BFAF18 /* Controller-Database.plist in Resources */ = {isa = PBXBuildFile; fileRef = 05F2F90724EA029900BFAF18 /* Controller-Database.plist */; };
 		05FC85B1295E49FE003DED0C /* NSDataCategoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */; };
+		DD44E55B72584A65AAD96E83 /* OEDeviceManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51F98C6E6EE94589914941EA /* OEDeviceManagerTests.m */; };
 		05FC85B2295E49FE003DED0C /* OpenEmuSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6772A8C1710CD7E00ED580A /* OpenEmuSystem.framework */; };
 		05FF41B822B08C5F00BB7283 /* OELogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 05FF41B622B08C5F00BB7283 /* OELogging.m */; };
 		05FF41B922B08C5F00BB7283 /* OELogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 05FF41B722B08C5F00BB7283 /* OELogging.h */; };
@@ -173,6 +174,7 @@
 		05F2F90724EA029900BFAF18 /* Controller-Database.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Controller-Database.plist"; sourceTree = "<group>"; };
 		05FC85AE295E49FE003DED0C /* OpenEmuSystemTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenEmuSystemTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSDataCategoryTests.m; sourceTree = "<group>"; };
+		51F98C6E6EE94589914941EA /* OEDeviceManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OEDeviceManagerTests.m; sourceTree = "<group>"; };
 		05FF41B622B08C5F00BB7283 /* OELogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OELogging.m; sourceTree = "<group>"; };
 		05FF41B722B08C5F00BB7283 /* OELogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OELogging.h; sourceTree = "<group>"; };
 		1E2F988CC2D67CFDA1EC461B /* OESystemConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = OESystemConstants.h; sourceTree = "<group>"; };
@@ -325,6 +327,7 @@
 			isa = PBXGroup;
 			children = (
 				05FC85B0295E49FE003DED0C /* NSDataCategoryTests.m */,
+				51F98C6E6EE94589914941EA /* OEDeviceManagerTests.m */,
 			);
 			path = OpenEmuSystemTests;
 			sourceTree = "<group>";
@@ -790,6 +793,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				05FC85B1295E49FE003DED0C /* NSDataCategoryTests.m in Sources */,
+				DD44E55B72584A65AAD96E83 /* OEDeviceManagerTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager.m
+++ b/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager.m
@@ -481,6 +481,13 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
 
 - (void)OE_addDeviceHandler:(__kindof OEDeviceHandler *)handler
 {
+    if(![handler isKindOfClass:[OEMultiHIDDeviceHandler class]]
+       && ![handler isKeyboardDevice]
+       && [[handler controllerDescription] numberOfControls] == 0) {
+        NSLog(@"OEDeviceManager: ignoring device handler %@, no controls could be read from it.", handler);
+        return;
+    }
+
     dispatch_barrier_async(_uniqueIdentifiersToDeviceHandlersQueue, ^{
         OEDeviceHandlerPlaceholder *placeholder = self->_uniqueIdentifiersToDeviceHandlers[handler.uniqueIdentifier];
         self->_uniqueIdentifiersToDeviceHandlers[handler.uniqueIdentifier] = handler;
@@ -509,7 +516,6 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
         [_keyboardHandlers addObject:handler];
         [self didChangeValueForKey:@"keyboardDeviceHandlers"];
     } else {
-        NSAssert([[handler controllerDescription] numberOfControls] > 0, @"Handler %@ does not have any controls.", handler);
         [handler setDeviceIdentifier:++_lastAttributedDeviceIdentifier];
         [self willChangeValueForKey:@"controllerDeviceHandlers"];
         [_deviceHandlers addObject:handler];

--- a/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager_Internal.h
+++ b/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager_Internal.h
@@ -26,6 +26,7 @@
 
 @interface OEDeviceManager ()
 
+- (void)OE_addDeviceHandler:(__kindof OEDeviceHandler *)handler;
 - (void)OE_removeDeviceHandler:(__kindof OEDeviceHandler *)handler;
 
 @end

--- a/OpenEmu-SDK/OpenEmuSystemTests/OEDeviceManagerTests.m
+++ b/OpenEmu-SDK/OpenEmuSystemTests/OEDeviceManagerTests.m
@@ -1,0 +1,63 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <XCTest/XCTest.h>
+#import <OpenEmuSystem/OpenEmuSystem.h>
+
+#import "../OpenEmuSystem/OEDeviceManager_Internal.h"
+#import "../OpenEmuSystem/OEControllerDescription_Internal.h"
+
+// Regression coverage for OES-300: a controller that macOS hands to OpenEmu
+// without any readable buttons/axes (seen in the field with an Xbox
+// controller on macOS 26) used to trip an NSAssert in
+// -[OEDeviceManager OE_addDeviceHandler:] and crash the app on launch.
+// That handler should now be ignored instead of asserted on.
+@interface OEDeviceManagerTests : XCTestCase
+
+@end
+
+@implementation OEDeviceManagerTests
+
+- (void)testDeviceHandlerWithNoControlsIsIgnoredRatherThanCrashing {
+    // An unrecognized vendor/product pair produces a generic controller
+    // description with zero controls, the same shape as the field crash.
+    OEControllerDescription *controllerDescription =
+        [OEControllerDescription OE_controllerDescriptionForVendorID:0xFFFF
+                                                             productID:0xFFFF
+                                                               product:@"Unit Test Fake Controller"];
+    XCTAssertEqual(controllerDescription.numberOfControls, 0);
+
+    OEDeviceDescription *deviceDescription = [controllerDescription deviceDescriptionForVendorID:0xFFFF
+                                                                                         productID:0xFFFF
+                                                                                            cookie:0];
+
+    OEDeviceHandler *handler = [[OEDeviceHandler alloc] initWithDeviceDescription:deviceDescription];
+    OEDeviceManager *manager = [OEDeviceManager sharedDeviceManager];
+
+    XCTAssertNoThrow([manager OE_addDeviceHandler:handler]);
+    XCTAssertFalse([manager.controllerDeviceHandlers containsObject:handler],
+                    @"A controller with zero readable controls should be skipped, not registered.");
+}
+
+@end


### PR DESCRIPTION
## What does this PR do?

Fixes a launch crash: when OpenEmu detects a controller whose handler ends up with zero readable buttons/axes, it used to hit an `NSAssert` and abort the whole app. Reported with an Xbox controller on macOS 26 (Tahoe) on Apple Silicon (nickybmon/OpenEmu-Silicon#656 / nickybmon/OpenEmu-Silicon#656) — most likely macOS 26 changed how it exposes that controller's HID elements. Now OpenEmu logs a warning and skips that device instead of crashing. This can't fix the underlying reason the controller reports zero controls (needs the actual hardware to diagnose further), but it stops the crash for any controller that hits this edge case.

## What did you test?

* `./Scripts/verify.sh`: build, static analyzer, plist lint, and codesign all pass.
* Added `OEDeviceManagerTests.m`, a new unit test that simulates a controller with zero readable controls (an unrecognized vendor/product ID) and asserts `OE_addDeviceHandler:` no longer throws and the device is not registered. Ran via `xcodebuild test -project OpenEmu-SDK/OpenEmu-SDK.xcodeproj -scheme OpenEmuSystem -destination 'platform=macOS'` — passes.
* Could not test against a real Xbox controller (none available). Asking the original reporter to confirm once this ships in a release.

## Which cores or systems are affected?

None — this is a general app-level fix in `OpenEmuSystem` (controller/HID device handling), not core-specific.

## Did you use AI tools?

Used Claude Code to investigate the crash report, trace the root cause in `OEDeviceManager.m`, implement the fix, and write the regression test.

## Linked issues

Related to nickybmon/OpenEmu-Silicon#656

---

## PR checklist

- [X] Branched from an up-to-date `main`
- [X] Build passes: `./Scripts/verify.sh`
- [ ] Tested on Apple Silicon with the actual controller (blocked — no Xbox controller available; reporter will confirm post-release)
- [X] No build logs, binaries, or credentials committed
- [X] Copyright headers preserved on all modified files
- [X] New files include the BSD 2-Clause license header