### PR TITLE
fix: route hybrid GamePad+Keyboard HIDs as controllers, not keyboards

### DIFF
--- a/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager.m
+++ b/OpenEmu-SDK/OpenEmuSystem/OEDeviceManager.m
@@ -467,7 +467,7 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
     NSAssert(device != NULL, @"Passing NULL device.");
 
     OEHIDDeviceHandler *handler = nil;
-    if(IOHIDDeviceConformsTo(device, kHIDPage_GenericDesktop, kHIDUsage_GD_Keyboard)) {
+    if([OEHIDDeviceHandler deviceIsKeyboardOnly:device]) {
         if (!istouchbar)
             handler = [[OEHIDDeviceHandler alloc] initWithIOHIDDevice:device deviceDescription:nil];
         else

--- a/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceHandler.h
+++ b/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceHandler.h
@@ -40,6 +40,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)canHandleDevice:(IOHIDDeviceRef)device;
 
+/** Whether a device is keyboard-only, i.e. conforms to the Keyboard usage
+ *  and does not also conform to GamePad or Joystick. A HID conforming to
+ *  Keyboard as well as GamePad/Joystick (e.g. some Bluetooth Xbox
+ *  controllers) is not keyboard-only, and must be routed through the
+ *  controller parser rather than treated as a keyboard. */
++ (BOOL)deviceIsKeyboardOnly:(IOHIDDeviceRef)device;
+
 - (instancetype)initWithDeviceDescription:(nullable OEDeviceDescription *)deviceDescription NS_UNAVAILABLE;
 - (instancetype)initWithIOHIDDevice:(IOHIDDeviceRef)aDevice deviceDescription:(nullable OEDeviceDescription *)deviceDescription NS_DESIGNATED_INITIALIZER;
 

--- a/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceHandler.m
+++ b/OpenEmu-SDK/OpenEmuSystem/OEHIDDeviceHandler.m
@@ -185,9 +185,16 @@ NS_ASSUME_NONNULL_BEGIN
     return (__bridge NSNumber *)IOHIDDeviceGetProperty(_device, CFSTR(kUSBInterfaceNumber));
 }
 
++ (BOOL)deviceIsKeyboardOnly:(IOHIDDeviceRef)device
+{
+    return IOHIDDeviceConformsTo(device, kHIDPage_GenericDesktop, kHIDUsage_GD_Keyboard)
+        && !IOHIDDeviceConformsTo(device, kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad)
+        && !IOHIDDeviceConformsTo(device, kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick);
+}
+
 - (BOOL)isKeyboardDevice;
 {
-    return IOHIDDeviceConformsTo(_device, kHIDPage_GenericDesktop, kHIDUsage_GD_Keyboard);
+    return [OEHIDDeviceHandler deviceIsKeyboardOnly:_device];
 }
 
 - (BOOL)isFunctionKeyPressed


### PR DESCRIPTION
## What does this PR do?

Fixes controller detection for HIDs that report conformance to both Keyboard and GamePad usages (confirmed with a Bluetooth Xbox Elite Wireless Controller Series 2). Previously, any device conforming to the Keyboard usage was routed to a bare keyboard handler before the controller parser ever ran, so a hybrid device silently disappeared — no entry in Controls preferences, no bindings possible.

## What did you test?

`./Scripts/verify.sh` — build, static analyzer, and codesign all pass with no new warnings. This fix has **not** been verified against real Bluetooth Xbox Elite Series 2 hardware — neither the reporter's controller nor equivalent hardware was available during development. Needs manual verification before merge.

## Which cores or systems are affected?

General app change — controller discovery and Controls preferences (`OpenEmuSystem`), all systems.

## Did you use AI tools?

Used Claude to draft the fix, reviewed and tested (build/analyzer/codesign) myself; hardware verification still pending.

## Linked issues

Fixes #642

---

## How to test locally

The PR number below is filled in automatically — just paste the whole block. For Flycast use `-scheme "OpenEmu + Flycast"` with `clean build`; for Mednafen use `-scheme "OpenEmu + Mednafen" -configuration Release`.

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 672 --repo nickybmon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

If this PR touches a core, install it before launching:

```bash
./Scripts/install-core.sh <CoreName>
./Scripts/launch-debug.sh
```

`install-core.sh` quits OpenEmu first, copies files correctly, and re-signs the bundle.

**Hardware-specific steps for this PR:** pair a Bluetooth Xbox Elite Wireless Controller Series 2 (or another controller known to conform to both Keyboard and GamePad HID usages), grant Input Monitoring to the debug build, launch, open Settings → Controls, and confirm the controller appears as an input option (not "No available controllers").

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac) — build/analyzer/codesign verified; hardware-specific behavior not yet confirmed
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header

---

## Adversarial review

No blocking findings. Two notes surfaced, neither a regression introduced by this change:

1. If the controller parser's tree walk can't find a top-level GamePad/Joystick collection for an unrecognized hybrid device, it returns a nil handler and the device is dropped with no log line (pre-existing behavior in `OEHIDDeviceParser.m`, not touched by this diff — but this is the first time this specific device gets routed through that path). Worth watching for during hardware verification; if the Xbox Elite Series 2 doesn't appear even after this fix, check Console logs for "Found Device" with no follow-up rather than assuming the fix didn't work.
2. The Touch Bar special case is now gated behind the stricter `deviceIsKeyboardOnly:` check. This is safe today (Apple's virtual Touch Bar HID doesn't conform to GamePad/Joystick) but would silently fall through to the generic controller parser if that ever changed — not actionable now, just documented.

Also confirmed: the `NSAssert` in `OEHIDDeviceHandler.m` guarding non-nil device descriptions cannot fire for this fix's hybrid-device path (the controller parser always synthesizes a generic device description for unrecognized VID/PID pairs), and no other classification call site still uses the raw single-usage Keyboard check.