### PR TITLE
fix: keep long import alerts on screen

### DIFF
--- a/OpenEmu/OEAlert.swift
+++ b/OpenEmu/OEAlert.swift
@@ -57,6 +57,10 @@ final class OEAlert: NSObject {
     // onto the main queue, which NSApp.runModal(for:) processes normally.
     private var sheetMode = false
     private var needsRebuild = true
+
+    private var usesScrollableInformativeText: Bool {
+        informativeText.count > 1000 || informativeText.filter { $0 == "\n" }.count > 20
+    }
     
     // MARK: - Controls
     
@@ -648,6 +652,9 @@ final class OEAlert: NSObject {
             contentView.widthAnchor.constraint(greaterThanOrEqualToConstant: MinimumWidth),
             maxWidthConstraint,
         ])
+        if usesScrollableInformativeText {
+            contentView.widthAnchor.constraint(equalToConstant: MaximumWidth).isActive = true
+        }
         
         // Set preferredMaxLayoutWidth on the message and the headline text fields.
         // In this way, in case the text wraps, the width of the label will be
@@ -714,13 +721,43 @@ final class OEAlert: NSObject {
             messageLabel.isSelectable = true
         }
         
+        if usesScrollableInformativeText {
+            let maxTextWidth = MaximumWidth - TrailingInset - LeadingInset - ImageWidth - ImageLeadingInset
+            messageLabel.preferredMaxLayoutWidth = maxTextWidth
+
+            let documentHeight = max(messageLabel.fittingSize.height, 1)
+            let maximumHeight = max(120, (NSScreen.main?.visibleFrame.height ?? 800) - 220)
+            let documentView = NSView(frame: NSRect(x: 0, y: 0, width: maxTextWidth, height: documentHeight))
+            messageLabel.translatesAutoresizingMaskIntoConstraints = true
+            messageLabel.frame = documentView.bounds
+            messageLabel.autoresizingMask = [.width, .height]
+            documentView.addSubview(messageLabel)
+
+            let scrollView = NSScrollView()
+            scrollView.translatesAutoresizingMaskIntoConstraints = false
+            scrollView.drawsBackground = false
+            scrollView.borderType = .noBorder
+            scrollView.hasVerticalScroller = documentHeight > maximumHeight
+            scrollView.autohidesScrollers = true
+            scrollView.documentView = documentView
+            contentView.addSubview(scrollView)
+            NSLayoutConstraint.activate([
+                scrollView.topAnchor.constraint(equalTo: lastAnchor, constant: hasHeadline ? HeadlineToMessageSpacing : TopInset),
+                scrollView.leadingAnchor.constraint(equalTo: effectiveLeadingAnchor, constant: LeadingInset),
+                contentView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: TrailingInset),
+                scrollView.heightAnchor.constraint(equalToConstant: min(documentHeight, maximumHeight)),
+            ])
+
+            return scrollView.bottomAnchor
+        }
+
         contentView.addSubview(messageLabel)
         NSLayoutConstraint.activate([
             messageLabel.topAnchor.constraint(equalTo: lastAnchor, constant: hasHeadline ? HeadlineToMessageSpacing : TopInset),
             messageLabel.leadingAnchor.constraint(equalTo: effectiveLeadingAnchor, constant: LeadingInset),
             contentView.trailingAnchor.constraint(greaterThanOrEqualTo: messageLabel.trailingAnchor, constant: TrailingInset),
         ])
-        
+
         return messageLabel.bottomAnchor
     }
     

--- a/OpenEmu/OEAlert.swift
+++ b/OpenEmu/OEAlert.swift
@@ -26,6 +26,11 @@ import Cocoa
 
 typealias OEAlertCompletionHandler = (OEAlert, NSApplication.ModalResponse) -> Void
 
+// Flipped so scroll views using it as a document view open at the top instead of the bottom.
+private final class FlippedView: NSView {
+    override var isFlipped: Bool { true }
+}
+
 @objc
 @objcMembers
 final class OEAlert: NSObject {
@@ -727,7 +732,8 @@ final class OEAlert: NSObject {
 
             let documentHeight = max(messageLabel.fittingSize.height, 1)
             let maximumHeight = max(120, (NSScreen.main?.visibleFrame.height ?? 800) - 220)
-            let documentView = NSView(frame: NSRect(x: 0, y: 0, width: maxTextWidth, height: documentHeight))
+            // Flipped so the scroll view opens showing the top of the text, not the bottom.
+            let documentView = FlippedView(frame: NSRect(x: 0, y: 0, width: maxTextWidth, height: documentHeight))
             messageLabel.translatesAutoresizingMaskIntoConstraints = true
             messageLabel.frame = documentView.bounds
             messageLabel.autoresizingMask = [.width, .height]
@@ -751,6 +757,7 @@ final class OEAlert: NSObject {
             return scrollView.bottomAnchor
         }
 
+        messageLabel.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(messageLabel)
         NSLayoutConstraint.activate([
             messageLabel.topAnchor.constraint(equalTo: lastAnchor, constant: hasHeadline ? HeadlineToMessageSpacing : TopInset),


### PR DESCRIPTION
## What does this PR do?

Fixes the long failed-import alert shown after an initial library scan. When the scan produces a large failure report, the informative text is now placed in a bounded scroll view so the alert stays on screen and its buttons remain accessible.

## What did you test?

- `swiftc -parse OpenEmu/OEAlert.swift`
- `git diff --check`
- `./Scripts/verify.sh` — passes build, static analysis, plist checks, and codesign verification.
- Runtime testing on macOS is still required with a scan that produces many failed imports.

## Which cores or systems are affected?

General app UI only. No emulator cores or systems are changed.

## Did you use AI tools?

Used Pi to inspect the issue and code, draft the fix, and prepare this pull request.

## Linked issues

Fixes #627

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout 685 --repo OpenEmu-Silicon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

After launching, run an import scan containing enough unsupported or invalid files to produce a long failed-import report. Verify that the alert remains within the screen, its message can be scrolled, and both action buttons remain visible and usable. Pressing the default button should still open the importing guide in a browser.

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh`
- [ ] Tested on Apple Silicon (requires local macOS/Xcode runtime testing)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on modified files
- [x] New files (none) include the BSD 2-Clause license header
