### PR TITLE
fix: use standard search field

### DIFF
--- a/OpenEmu/LibraryToolbarDelegate.swift
+++ b/OpenEmu/LibraryToolbarDelegate.swift
@@ -224,7 +224,7 @@ final class LibraryToolbarDelegate: NSObject, NSToolbarDelegate {
     // MARK: - Search
     
     private(set) lazy var searchField: NSSearchField = {
-        let searchField = NSSearchField()
+        let searchField = OESearchField()
         searchField.lineBreakMode = .byClipping
         searchField.usesSingleLineMode = true
         searchField.cell?.isScrollable = true

--- a/OpenEmu/LibraryToolbarDelegate.swift
+++ b/OpenEmu/LibraryToolbarDelegate.swift
@@ -223,8 +223,8 @@ final class LibraryToolbarDelegate: NSObject, NSToolbarDelegate {
     
     // MARK: - Search
     
-    private(set) lazy var searchField: OESearchField = {
-        let searchField = OESearchField()
+    private(set) lazy var searchField: NSSearchField = {
+        let searchField = NSSearchField()
         searchField.lineBreakMode = .byClipping
         searchField.usesSingleLineMode = true
         searchField.cell?.isScrollable = true

--- a/OpenEmu/OESearchField.swift
+++ b/OpenEmu/OESearchField.swift
@@ -24,61 +24,12 @@
 
 import Cocoa
 
-@available(macOS, introduced: 10.14, deprecated: 11.0, message: "Remove everything but searchMenuTemplate.")
 final class OESearchField: NSSearchField {
-    
+
     // Force redraw of the search glyph after changing the menu to make sure the chevron is displayed.
     override var searchMenuTemplate: NSMenu? {
         didSet {
             (cell as? NSSearchFieldCell)?.resetSearchButtonCell()
-        }
-    }
-    
-    // Due to a bug in AppKit, the background of a disabled search field is not dimmed when its window moves into the background.
-    // As a workaround, enable the search field when it goes into background and restore its state once its window becomes key again
-    // (unless the enabled state changed in the meantime).
-    // Should be removed once support for Catalina is dropped.
-    var wasEnabled: Bool?
-    var isInBackground = false
-    
-    override var isEnabled: Bool {
-        didSet {
-            if isInBackground {
-                wasEnabled = nil
-            }
-        }
-    }
-    
-    override func viewWillMove(toWindow newWindow: NSWindow?) {
-        super.viewWillMove(toWindow: newWindow)
-        
-        if #available(macOS 11.0, *) {
-            return
-        } else {
-            
-            if window != nil {
-                NotificationCenter.default.removeObserver(self, name: NSWindow.didBecomeMainNotification, object: window)
-                NotificationCenter.default.removeObserver(self, name: NSWindow.didResignMainNotification, object: window)
-            }
-            
-            if newWindow != nil {
-                NotificationCenter.default.addObserver(self, selector: #selector(windowDidBecomeMain), name: NSWindow.didBecomeMainNotification, object: newWindow)
-                NotificationCenter.default.addObserver(self, selector: #selector(windowDidResignMain), name: NSWindow.didResignMainNotification, object: newWindow)
-            }
-        }
-    }
-    
-    @objc func windowDidResignMain() {
-        wasEnabled = isEnabled
-        isEnabled = true
-        isInBackground = true
-    }
-    
-    @objc func windowDidBecomeMain() {
-        isInBackground = false
-        if wasEnabled != nil {
-            isEnabled = wasEnabled!
-            wasEnabled = nil
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Related to #665. Replaces the library toolbar's deprecated `OESearchField` usage with the standard `NSSearchField`. This PR intentionally covers only the search-field warning; the larger `IKImageBrowserView` to `NSCollectionView` migration will be handled in a separate follow-up PR.

## What did you test?

- `swiftc -parse OpenEmu/LibraryToolbarDelegate.swift`
- `git diff --check`
- `./Scripts/verify.sh` — passes build, static analysis, plist checks, and codesign verification.
- The build no longer reports the `OESearchField` deprecation warning. The existing `IKImageBrowserView` warning remains for the follow-up PR.

## Which cores or systems are affected?

General library toolbar UI only. No emulator cores or systems are changed.

## Did you use AI tools?

Used Pi to inspect issue #665, draft this focused change, run verification, and prepare this pull request.

## Linked issues

Related to #665

---

## How to test locally

```bash
gh repo clone OpenEmu-Silicon/OpenEmu-Silicon
cd OpenEmu-Silicon
gh pr checkout 686 --repo OpenEmu-Silicon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

After launching, open the library window and verify that the toolbar search field accepts text, submits searches, and retains its search-menu behavior. Switch between the library categories and confirm the toolbar remains functional.

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh`
- [ ] Tested on Apple Silicon with manual UI interaction
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on modified files
- [x] New files (none) include the BSD 2-Clause license header
