### PR TITLE
fix: correct LICENSE.md to reflect actual BSD-3-Clause status of inherited code

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,27 @@
-BSD 2-Clause License
+This project is a derivative of OpenEmu (https://github.com/OpenEmu/OpenEmu),
+copyright the OpenEmu Team. It is not affiliated with or endorsed by the
+OpenEmu Team.
 
-Copyright (c) 2024, OpenEmu Team
-All rights reserved.
+Most source files in this repository carry the OpenEmu Team's original
+copyright header and are governed by the terms in that header, reproduced
+below (BSD 3-Clause, including the restriction on using the OpenEmu name).
+That per-file header is authoritative for that file. Where a file's own
+header states different terms (for example, original work not derived from
+OpenEmu, or a third-party emulator core under its own license), that file's
+own header governs instead, not this notice.
+
+This LICENSE file previously claimed a blanket BSD 2-Clause license for the
+whole project. That was inaccurate: the majority of files never carried a
+2-Clause header, and a top-level LICENSE file cannot unilaterally relicense
+code whose actual copyright holder (the OpenEmu Team) released it under
+different, stricter terms. This file has been corrected to reflect what the
+source actually says.
+
+---
+
+BSD 3-Clause License
+
+Copyright (c) OpenEmu Team
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -12,6 +32,10 @@ modification, are permitted provided that the following conditions are met:
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
+
+3. Neither the name of the OpenEmu Team nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/README.md
+++ b/README.md
@@ -104,6 +104,6 @@ If you want to contribute code, check the open issues for good starting points. 
 
 ## License
 
-The main OpenEmu app and SDK are licensed under the **BSD 2-Clause License**. Individual emulation cores carry their own licenses (GPL v2, MPL 2.0, LGPL 2.1, and others) — see each core's directory for details.
+This project is a derivative of [OpenEmu](https://github.com/OpenEmu/OpenEmu). Most of the main app and SDK still carries the OpenEmu Team's original **BSD 3-Clause** copyright header, which is what actually governs those files — see [`LICENSE`](LICENSE) for the full text and how it applies. Individual emulation cores carry their own licenses (GPL v2, MPL 2.0, LGPL 2.1, and others) — see each core's directory for details.
 
 Note: [picodrive](https://github.com/notaz/picodrive) includes a non-commercial clause. This project is and will remain free.


### PR DESCRIPTION
## What does this PR do?

Corrects `LICENSE` and the README's License section, which claimed a blanket BSD 2-Clause license for the whole project. Checked the actual per-file copyright headers: most source under `OpenEmu/`, `OpenEmu-SDK/`, `OpenEmuKit/`, and `OpenEmu-Shaders/` still carries the original OpenEmu Team header, which is BSD 3-Clause — including the clause restricting use of the OpenEmu name to endorse/promote derived products. A top-level `LICENSE` file can't unilaterally relicense code whose actual copyright holder released it under stricter terms, so the file was simply inaccurate.

Fix: state plainly that most files carry the original OpenEmu Team header and are governed by its terms (reproduced in full), and that any file with different terms in its own header is governed by that instead. No blanket claim either way.

Tracked in Linear as OES-320, part of the "Drop OpenEmu Identity" project — this issue was scoped as independent of the rename work and safe to do first.

## What did you test?

Docs-only change, no build impact. Verified the actual header text present in `OpenEmu/OECredentialStore.swift`, `OpenEmu/OESaveSyncManager.swift`, `OpenEmu/OEFolderBackupManager.swift` and a broader scan (318/449 files in `OpenEmu/`, 99/117 in `OpenEmu-SDK/`, 77/78 in `OpenEmuKit/`, 35/44 in `OpenEmu-Shaders/` carry the 3-clause header) before writing the correction.

## Which cores or systems are affected?

None — general project documentation only. Per-core license disclaimers are unchanged.

## Did you use AI tools?

Used Claude to identify the discrepancy (comparing the declared LICENSE against actual per-file headers), scope which directories were affected, and draft the corrected text. Reviewed and verified myself.

## Linked issues

Related to OES-320

---

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Docs-only change — no build required
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files