### PR TITLE
fix: correct Jaguar core aspect ratio to 4:3 landscape

### DIFF
--- a/VirtualJaguar/VirtualJaguar/JaguarGameCore.mm
+++ b/VirtualJaguar/VirtualJaguar/JaguarGameCore.mm
@@ -124,6 +124,11 @@ static JaguarGameCore *current;
     return OEIntSizeMake(videoWidth, videoHeight);
 }
 
+- (OEIntSize)aspectSize
+{
+    return OEIntSizeMake(4, 3);
+}
+
 - (const void *)getVideoBufferWithHint:(void *)hint
 {
     if (hint && hint != buffer) {


### PR DESCRIPTION
## What does this PR do?

VirtualJaguar's `JaguarGameCore` never overrode `-aspectSize`, so it fell through to the SDK's base `OEGameCore` default of 1:1. The TOM chip's raw buffer width varies per game and is often narrower than tall, so without an aspect override the host rendered games in portrait instead of landscape. Adds a `-aspectSize` override returning 4:3.

## What did you test?

Built and installed the VirtualJaguar core via `Scripts/install-core.sh`, confirmed via `./Scripts/verify.sh --core VirtualJaguar` (build, codesign, install, hash verification all pass).

## Which cores or systems are affected?

VirtualJaguar (Atari Jaguar) only.

## Did you use AI tools?

Used Claude to draft the fix, reviewed and verified it myself.

## Linked issues

Fixes #703

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh --core VirtualJaguar`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files