### PR TITLE
feat: add preference to hide RA hardcore-mode shield icon

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -156,6 +156,7 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
             OEForcePopoutGameWindowKey: true,
             OEPopoutGameWindowIntegerScalingOnlyKey: true,
             OEGameLayerNotificationView.OEShowNotificationsKey : true,
+            OEGameLayerNotificationView.OEShowHardcoreIconKey : true,
             OEAppearance.Application.key: OEAppearance.Application.dark.rawValue,
             OEAppearance.HUDBar.key: OEAppearance.HUDBar.vibrant.rawValue,
             OEAppearance.ControlsPrefs.key: OEAppearance.ControlsPrefs.wood.rawValue,

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -559,6 +559,7 @@ final class OERetroAchievementsIndicatorStackView: NSStackView {
 final class OEGameLayerNotificationView: NSImageView {
     
     static let OEShowNotificationsKey = "OEShowNotifications"
+    static let OEShowHardcoreIconKey = "OEShowHardcoreIcon"
     
     public var disableNotifications: Bool = false
     
@@ -621,6 +622,13 @@ final class OEGameLayerNotificationView: NSImageView {
     }
 
     @objc public func showHardcore(enabled: Bool) {
+        guard UserDefaults.standard.bool(forKey: Self.OEShowHardcoreIconKey) else {
+            isHardcoreMode = enabled
+            if enabled {
+                postAccessibilityNotification(announcement: NSLocalizedString("Hardcore Mode", tableName: "ControlLabels", comment: ""))
+            }
+            return
+        }
         performNotification(img: hardcoreImage, enabled: enabled, state: &isHardcoreMode)
         if enabled {
             postAccessibilityNotification(announcement: NSLocalizedString("Hardcore Mode", tableName: "ControlLabels", comment: ""))

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -623,7 +623,14 @@ final class OEGameLayerNotificationView: NSImageView {
 
     @objc public func showHardcore(enabled: Bool) {
         guard UserDefaults.standard.bool(forKey: Self.OEShowHardcoreIconKey) else {
-            isHardcoreMode = enabled
+            // Deliberately leave isHardcoreMode untouched here rather than
+            // setting it directly: performNotification's idempotency guard
+            // (`if enabled && state { return }`) reads that same variable,
+            // so writing it out of band would desync the two and could
+            // permanently suppress the icon for the rest of the session if
+            // the user re-enables this preference while still in hardcore
+            // mode (the guard would see enabled && state both true and
+            // no-op before ever drawing anything).
             if enabled {
                 postAccessibilityNotification(announcement: NSLocalizedString("Hardcore Mode", tableName: "ControlLabels", comment: ""))
             }

--- a/OpenEmu/PrefRetroAchievementsController.swift
+++ b/OpenEmu/PrefRetroAchievementsController.swift
@@ -57,6 +57,7 @@ final class PrefRetroAchievementsController: NSViewController {
     private let hardcoreDivider = NSBox()
     private let hardcoreCheckbox = NSButton(checkboxWithTitle: "Hardcore mode (recommended)", target: nil, action: nil)
     private let hardcoreSubtitle = NSTextField(wrappingLabelWithString: "")
+    private let hardcoreIconCheckbox = NSButton(checkboxWithTitle: "Show hardcore mode icon during gameplay", target: nil, action: nil)
 
     private let supportedDivider = NSBox()
     private let supportedLabel   = NSTextField(labelWithString: "")
@@ -67,7 +68,7 @@ final class PrefRetroAchievementsController: NSViewController {
     // MARK: - Lifecycle
 
     override func loadView() {
-        view = NSView(frame: NSRect(x: 0, y: 0, width: 468, height: 580))
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 468, height: 610))
         buildUI()
     }
 
@@ -181,6 +182,12 @@ final class PrefRetroAchievementsController: NSViewController {
         hardcoreSubtitle.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(hardcoreSubtitle)
 
+        hardcoreIconCheckbox.target = self
+        hardcoreIconCheckbox.action = #selector(toggleHardcoreIcon(_:))
+        hardcoreIconCheckbox.state = UserDefaults.standard.bool(forKey: OEGameLayerNotificationView.OEShowHardcoreIconKey) ? .on : .off
+        hardcoreIconCheckbox.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hardcoreIconCheckbox)
+
         NSLayoutConstraint.activate([
             headerLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 32),
             headerLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),
@@ -234,6 +241,10 @@ final class PrefRetroAchievementsController: NSViewController {
             hardcoreSubtitle.topAnchor.constraint(equalTo: hardcoreCheckbox.bottomAnchor, constant: 4),
             hardcoreSubtitle.leadingAnchor.constraint(equalTo: hardcoreCheckbox.leadingAnchor, constant: 20),
             hardcoreSubtitle.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
+
+            hardcoreIconCheckbox.topAnchor.constraint(equalTo: hardcoreSubtitle.bottomAnchor, constant: 12),
+            hardcoreIconCheckbox.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),
+            hardcoreIconCheckbox.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
         ])
 
         // ── Supported Systems ────────────────────────────────────────────────
@@ -253,7 +264,7 @@ final class PrefRetroAchievementsController: NSViewController {
         view.addSubview(supportedGrid)
 
         NSLayoutConstraint.activate([
-            supportedDivider.topAnchor.constraint(equalTo: hardcoreSubtitle.bottomAnchor, constant: 24),
+            supportedDivider.topAnchor.constraint(equalTo: hardcoreIconCheckbox.bottomAnchor, constant: 24),
             supportedDivider.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 36),
             supportedDivider.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -36),
             supportedDivider.heightAnchor.constraint(equalToConstant: 1),
@@ -341,6 +352,10 @@ final class PrefRetroAchievementsController: NSViewController {
             object: nil,
             userInfo: [OEHardcoreEnabledKey: enabled]
         )
+    }
+
+    @objc private func toggleHardcoreIcon(_ sender: NSButton) {
+        UserDefaults.standard.set(sender.state == .on, forKey: OEGameLayerNotificationView.OEShowHardcoreIconKey)
     }
 
     // MARK: - Credential Management
@@ -443,7 +458,7 @@ extension PrefRetroAchievementsController: PreferencePane {
 
     var panelTitle: String { "Achievements" }
 
-    var viewSize: NSSize { NSSize(width: 468, height: 580) }
+    var viewSize: NSSize { NSSize(width: 468, height: 610) }
 }
 
 


### PR DESCRIPTION
## What does this PR do?

Adds a dedicated preference to hide the RetroAchievements hardcore-mode shield icon that appears in the HUD, without affecting other HUD notifications. Adds a new `OEShowHardcoreIconKey` default (true) and a checkbox in Preferences → Achievements, mirroring the existing "Hardcore mode" checkbox. The VoiceOver accessibility announcement for hardcore mode is unaffected by this toggle — only the visual icon is suppressed.

## What did you test?

`./Scripts/verify.sh --launch` (build, static analyzer, plist lint, codesign, smoke launch all pass). Manually toggled the new checkbox in Preferences → Achievements and confirmed the global "Show Notifications" toggle still suppresses everything as before.

## Which cores or systems are affected?

None — general app change (RetroAchievements HUD/preferences only).

## Did you use AI tools?

Used Claude to draft the fix, reviewed and verified it myself.

## Linked issues

Fixes #698

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh --launch`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files