### PR TITLE
fix: prevent overlapping labels in Controls preferences

### DIFF
--- a/OpenEmu/ControlsButtonSetupView.swift
+++ b/OpenEmu/ControlsButtonSetupView.swift
@@ -85,6 +85,8 @@ final class ControlsButtonSetupView: NSView {
         sections = parser.sections
         keyToButtonMap = parser.keyToButtonMap
         orderedKeys = parser.orderedKeys
+        cachedSectionHeights = []
+        cachedSectionHeightsWidth = -1
         for (key, button) in keyToButtonMap {
             button.bind(
                 .title,
@@ -158,7 +160,8 @@ final class ControlsButtonSetupView: NSView {
     
     func layoutSubviews() {
         let width = width
-        
+        updateSectionHeightCacheIfNeeded(width: width)
+
         // determine required height
         var frame = frame
         let viewHeight = viewHeight
@@ -239,20 +242,41 @@ final class ControlsButtonSetupView: NSView {
     }
     
     private var viewHeight: CGFloat {
-        var height: CGFloat = 0
-        for section in sections {
-            height += heightOfSection(section)
-        }
-        return height
+        cachedSectionHeights.reduce(0, +)
+    }
+
+    // heightOfSection does real NSCell text measurement per row (for labels
+    // that may wrap). layoutSectionHeadings re-derives section positions on
+    // every scroll bounds-change notification, so recomputing this on every
+    // call turned scrolling into an O(sections^2 * rows) text-layout cost
+    // per frame. Cache it here and only recompute when the row content or
+    // available width actually changes.
+    private var cachedSectionHeights: [CGFloat] = []
+    private var cachedSectionHeightsWidth: CGFloat = -1
+
+    private func updateSectionHeightCacheIfNeeded(width: CGFloat) {
+        guard cachedSectionHeights.count != sections.count || cachedSectionHeightsWidth != width else { return }
+        cachedSectionHeights = sections.map { heightOfSection($0) }
+        cachedSectionHeightsWidth = width
+    }
+
+    private func cachedHeightOfSection(at index: Int) -> CGFloat {
+        updateSectionHeightCacheIfNeeded(width: width)
+        guard index >= 0, index < cachedSectionHeights.count else { return 0 }
+        return cachedSectionHeights[index]
     }
 
     /// Computes a row's vertical extent, accounting for labels that wrap to
     /// more than one line so height-calculation and layout never drift apart.
     private func rowHeight(forLabel label: ControlsKeyLabel?) -> CGFloat {
         guard let label = label else { return itemHeight }
+        // .integral matches the rounding layoutSubviews applies to the real
+        // label rect before measuring it — without it, a fractional width
+        // (common on Retina/resizable panes) can make this predict a
+        // different wrapped line count than layoutSubviews actually renders.
         var labelRect = NSRect(x: 0, y: 0,
                                 width: width - leftGap - labelButtonSpacing - buttonWidth,
-                                height: 100000)
+                                height: 100000).integral
         var fitSize = label.cell?.cellSize(forBounds: labelRect) ?? .zero
         if fitSize.height > 30 {
             labelRect.size.width += 5
@@ -310,7 +334,7 @@ final class ControlsButtonSetupView: NSView {
             let sectionHeader = section.header
             
             let sectionStart = headerPositionOfSection(at: i)
-            let sectionHeight = heightOfSection(section)
+            let sectionHeight = cachedHeightOfSection(at: i)
             
             let sectionRect = NSRect(x: 0, y: sectionStart - sectionHeight, width: width, height: sectionHeight)
             let visibleSectionRect = visibleRect.intersection(sectionRect)
@@ -334,7 +358,7 @@ final class ControlsButtonSetupView: NSView {
     private func headerPositionOfSection(at index: Int) -> CGFloat {
         var y = bounds.height
         for i in 0..<index {
-            y -= heightOfSection(sections[i])
+            y -= cachedHeightOfSection(at: i)
         }
         return y
     }

--- a/OpenEmu/ControlsButtonSetupView.swift
+++ b/OpenEmu/ControlsButtonSetupView.swift
@@ -213,7 +213,7 @@ final class ControlsButtonSetupView: NSView {
                     button.frame = buttonRect.integral
                     
                     var labelRect = NSRect(x: leftGap, y: buttonRect.origin.y + buttonRect.size.height / 2 + 1, width: width - leftGap - labelButtonSpacing - buttonWidth, height: 100000).integral
-                    
+
                     var labelFitSize = label.cell?.cellSize(forBounds: labelRect) ?? .zero
                     if labelFitSize.height > 30 {
                         // If the label size returned is too tall, enlarge the
@@ -224,10 +224,10 @@ final class ControlsButtonSetupView: NSView {
                     }
                     labelRect.origin.y -= labelFitSize.height / 2
                     labelRect.size.height = labelFitSize.height
-                    
+
                     label.frame = labelRect
-                    
-                    y -= itemHeight + verticalItemSpacing
+
+                    y -= rowHeight(forLabel: label) + verticalItemSpacing
                 }
             }
             
@@ -245,14 +245,42 @@ final class ControlsButtonSetupView: NSView {
         }
         return height
     }
-    
+
+    /// Computes a row's vertical extent, accounting for labels that wrap to
+    /// more than one line so height-calculation and layout never drift apart.
+    private func rowHeight(forLabel label: ControlsKeyLabel?) -> CGFloat {
+        guard let label = label else { return itemHeight }
+        var labelRect = NSRect(x: 0, y: 0,
+                                width: width - leftGap - labelButtonSpacing - buttonWidth,
+                                height: 100000)
+        var fitSize = label.cell?.cellSize(forBounds: labelRect) ?? .zero
+        if fitSize.height > 30 {
+            labelRect.size.width += 5
+            fitSize = label.cell?.cellSize(forBounds: labelRect) ?? .zero
+        }
+        return max(itemHeight, fitSize.height)
+    }
+
     private func heightOfSection(_ section: Section) -> CGFloat {
         var height = sectionTitleHeight
-        
+
         height += topGap + bottomGap
-        let numberOfRows = CGFloat(section.numberOfRows)
-        height += (numberOfRows - 1) * verticalItemSpacing + numberOfRows * itemHeight
-        
+
+        var rowHeights: [CGFloat] = []
+        for group in section.groups {
+            for row in group {
+                if row.0 is ControlsKeyButton, let label = row.1 as? ControlsKeyLabel {
+                    rowHeights.append(rowHeight(forLabel: label))
+                } else {
+                    rowHeights.append(itemHeight)
+                }
+            }
+        }
+
+        guard !rowHeights.isEmpty else { return height }
+        let numberOfRows = CGFloat(rowHeights.count)
+        height += (numberOfRows - 1) * verticalItemSpacing + rowHeights.reduce(0, +)
+
         return height
     }
     


### PR DESCRIPTION
## What does this PR do?

Fixes overlapping label text in the Controls preferences panel. `ControlsButtonSetupView` advanced each row by a fixed `itemHeight` in both `heightOfSection(_:)` and the `layoutSubviews()` row loop, even though `layoutSubviews()` already measures a label's actual wrapped height for frame-sizing. A row with a 2-3 line wrapped label (long key names combined with the button column eating into label width) overflowed its fixed slot and bled into the row below — most visibly in the Special Keys section ("Next Display Mode", "Last Display Mode", "Screenshot").

Extracts the label-height measurement into a shared `rowHeight(forLabel:)` helper used by both `heightOfSection(_:)` and `layoutSubviews()`, so the computed section height and the actual row advance can never drift apart. Single-line-label rows are unaffected (their measured height still equals `itemHeight`).

## What did you test?

`./Scripts/verify.sh --launch`, then manually opened Preferences → Controls → GameCube and confirmed the Special Keys rows ("Rewind", "Fast Forward", "Step Backward", "Step Forward", "Next Display Mode", "Last Display Mode", "Screenshot") no longer overlap. Spot-checked a single-line-label section (D-Pad, on Atari Jaguar) for zero visual change.

## Which cores or systems are affected?

None — general app change (Controls preferences panel).

## Did you use AI tools?

Used Claude to draft the fix, reviewed and verified it myself.

## Linked issues

Fixes #700

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh --launch`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files