### PR TITLE
fix: use the real rc_client transport for RetroAchievements login

### DIFF
--- a/OpenEmu/OpenEmu-Bridging-Header.h
+++ b/OpenEmu/OpenEmu-Bridging-Header.h
@@ -23,3 +23,5 @@
 #import "NSDocument+OEAdditions.h"
 #import "AppKit+ApplePrivate.h"
 #import "XADArchive+OE.h"
+
+#import "OERetroAchievementsLoginClient.h"

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -688,6 +688,9 @@
 		OE0RA0APPBUILDFILE0000001 /* PrefRetroAchievementsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OE0RA0APPFILEREF00000001 /* PrefRetroAchievementsController.swift */; };
 		OE0RA0BUILDFILE0000000001 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0RA0FILEREF00000000001 /* OERetroAchievementsTransport.m */; };
 		OE0RC0BUILDFILE0000000001 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0RC0FILEREF00000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1"; }; };
+		OE0RA0APPBUILDFILE0000002 /* OERetroAchievementsTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0RA0FILEREF00000000001 /* OERetroAchievementsTransport.m */; };
+		OE0RC0APPBUILDFILE0000002 /* rcheevos_build.c in Sources */ = {isa = PBXBuildFile; fileRef = OE0RC0FILEREF00000000001 /* rcheevos_build.c */; settings = {COMPILER_FLAGS = "-DRC_NO_THREADS=1"; }; };
+		OE0RALOGIN0BUILDFILE0002 /* OERetroAchievementsLoginClient.m in Sources */ = {isa = PBXBuildFile; fileRef = OE0RALOGIN0FILEREF0002 /* OERetroAchievementsLoginClient.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1948,6 +1951,8 @@
 		OE0RA0APPFILEREF00000001 /* PrefRetroAchievementsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefRetroAchievementsController.swift; sourceTree = "<group>"; };
 		OE0RA0FILEREF00000000001 /* OERetroAchievementsTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsTransport.m; path = ../OpenEmuKit/Source/OERetroAchievementsTransport.m; sourceTree = SOURCE_ROOT; };
 		OE0RC0FILEREF00000000001 /* rcheevos_build.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rcheevos_build.c; path = ../Vendor/rcheevos/rcheevos_build.c; sourceTree = SOURCE_ROOT; };
+		OE0RALOGIN0FILEREF0001 /* OERetroAchievementsLoginClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OERetroAchievementsLoginClient.h; path = ../OpenEmuKit/Source/OERetroAchievementsLoginClient.h; sourceTree = SOURCE_ROOT; };
+		OE0RALOGIN0FILEREF0002 /* OERetroAchievementsLoginClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OERetroAchievementsLoginClient.m; path = ../OpenEmuKit/Source/OERetroAchievementsLoginClient.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2953,6 +2958,8 @@
 				8F40EB7A1C1072B100683055 /* PrefCoresController.xib */,
 				CC0011223344556801900001 /* PrefScreenScraperController.swift */,
 				OE0RA0APPFILEREF00000001 /* PrefRetroAchievementsController.swift */,
+				OE0RALOGIN0FILEREF0001 /* OERetroAchievementsLoginClient.h */,
+				OE0RALOGIN0FILEREF0002 /* OERetroAchievementsLoginClient.m */,
 				CC0011223344557001900001 /* ScreenScraperDevCredentials.swift */,
 				83495DD319A38F31009DB6E5 /* PrefBiosController.swift */,
 				83495DD719A38F3D009DB6E5 /* PrefBiosController.xib */,
@@ -6286,6 +6293,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				OE0RALOGIN0BUILDFILE0002 /* OERetroAchievementsLoginClient.m in Sources */,
+				OE0RA0APPBUILDFILE0000002 /* OERetroAchievementsTransport.m in Sources */,
+				OE0RC0APPBUILDFILE0000002 /* rcheevos_build.c in Sources */,
 				C6252DC814E7A38000350A13 /* ControlsButtonSetupView.swift in Sources */,
 				0586AB22231A1E9A00BCDA6B /* OEGameLayerNotificationView.swift in Sources */,
 				0544B69923D16D0C00F63D61 /* ImageCollectionHeaderView.swift in Sources */,
@@ -8391,7 +8401,12 @@
 					"SUPPORTS_LIBRARY_REGISTRATION=1",
 				);
 				GCC_WARN_UNUSED_LABEL = YES;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**",
+					"$(SRCROOT)/../OpenEmuKit/Source",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+				);
 				INFOPLIST_FILE = "OpenEmu-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				INSTALL_PATH = /Applications;
@@ -8431,7 +8446,12 @@
 					"SUPPORTS_LIBRARY_REGISTRATION=1",
 				);
 				GCC_WARN_UNUSED_LABEL = YES;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**",
+					"$(SRCROOT)/../OpenEmuKit/Source",
+					"$(SRCROOT)/../Vendor/rcheevos/include",
+					"$(SRCROOT)/../Vendor/rcheevos/src",
+				);
 				INFOPLIST_FILE = "OpenEmu-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				INSTALL_PATH = /Applications;

--- a/OpenEmu/PrefRetroAchievementsController.swift
+++ b/OpenEmu/PrefRetroAchievementsController.swift
@@ -397,10 +397,9 @@ final class PrefRetroAchievementsController: NSViewController {
         statusLabel.stringValue = "Signing in…"
         statusLabel.textColor = .secondaryLabelColor
 
-        RetroAchievementsAPI.login(username: username, password: password) { [weak self] result in
+        OERetroAchievementsLoginClient.login(withUsername: username, password: password) { [weak self] token, _, error in
             guard let self = self else { return }
-            switch result {
-            case .success(let token):
+            if let token = token {
                 OECredentialStore.shared.set(token, forKey: .retroAchievementsToken)
                 UserDefaults.standard.set(username, forKey: "RAUsername")
                 self.passwordField.stringValue = ""
@@ -413,8 +412,8 @@ final class PrefRetroAchievementsController: NSViewController {
                     object: nil,
                     userInfo: [RACredentialsTokenKey: token, RACredentialsUsernameKey: username]
                 )
-            case .failure(let error):
-                self.setStatus(error.localizedDescription, isError: true)
+            } else {
+                self.setStatus(error?.localizedDescription ?? "Login failed. Check username and password.", isError: true)
             }
         }
     }
@@ -444,67 +443,4 @@ extension PrefRetroAchievementsController: PreferencePane {
     var panelTitle: String { "Achievements" }
 
     var viewSize: NSSize { NSSize(width: 468, height: 580) }
-}
-
-
-
-// MARK: - RA API
-
-private enum RetroAchievementsAPI {
-
-    enum LoginError: LocalizedError {
-        case networkError(Error)
-        case invalidResponse
-        case authFailed(String)
-
-        var errorDescription: String? {
-            switch self {
-            case .networkError(let e): return "Network error: \(e.localizedDescription)"
-            case .invalidResponse:     return "Unexpected response from RetroAchievements."
-            case .authFailed(let msg): return msg
-            }
-        }
-    }
-
-    /// GET login credentials and return the RA token on success.
-    static func login(username: String, password: String,
-                      completion: @escaping (Result<String, LoginError>) -> Void) {
-        var components = URLComponents(string: "https://retroachievements.org/dorequest.php")!
-        components.queryItems = [
-            URLQueryItem(name: "r", value: "login2"),
-            URLQueryItem(name: "u", value: username),
-            URLQueryItem(name: "p", value: password),
-        ]
-        guard let url = components.url else {
-            completion(.failure(.invalidResponse))
-            return
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("OpenEmu-Silicon/1.0 (macOS)", forHTTPHeaderField: "User-Agent")
-
-        URLSession.shared.dataTask(with: request) { data, response, error in
-            if let error = error {
-                NSLog("[RA] Network error: %@", error.localizedDescription)
-                DispatchQueue.main.async { completion(.failure(.networkError(error))) }
-                return
-            }
-
-            guard let data = data,
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else {
-                DispatchQueue.main.async { completion(.failure(.invalidResponse)) }
-                return
-            }
-
-            if let token = json["Token"] as? String, !token.isEmpty {
-                DispatchQueue.main.async { completion(.success(token)) }
-            } else {
-                let message = (json["Error"] as? String) ?? "Login failed. Check username and password."
-                NSLog("[RA] Auth failed: %@", message)
-                DispatchQueue.main.async { completion(.failure(.authFailed(message))) }
-            }
-        }.resume()
-    }
 }

--- a/OpenEmuKit/Source/OERetroAchievementsLoginClient.h
+++ b/OpenEmuKit/Source/OERetroAchievementsLoginClient.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^OERetroAchievementsLoginCompletion)(NSString * _Nullable token,
+                                                     NSString * _Nullable displayName,
+                                                     NSError * _Nullable error);
+
+/// Standalone RetroAchievements password login, used by the account sign-in
+/// UI (no emulator core or ROM involved). Goes through the same rc_client
+/// transport (`oeRetroAchievementsServerCall`) that in-game sessions use —
+/// a real POST request with an RA-compliant User-Agent — instead of a
+/// hand-rolled GET request.
+@interface OERetroAchievementsLoginClient : NSObject
+
+/// Attempts to log in with a RetroAchievements username/password. Calls
+/// `completion` on the main thread exactly once with either a token and
+/// display name, or an error.
++ (void)loginWithUsername:(NSString *)username
+                  password:(NSString *)password
+                completion:(OERetroAchievementsLoginCompletion)completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OpenEmuKit/Source/OERetroAchievementsLoginClient.m
+++ b/OpenEmuKit/Source/OERetroAchievementsLoginClient.m
@@ -1,0 +1,90 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import "OERetroAchievementsLoginClient.h"
+#import "OERetroAchievementsTransport.h"
+#include <rc_client.h>
+
+static NSString *const OERetroAchievementsLoginErrorDomain = @"org.openemu.RetroAchievementsLogin";
+
+// Login never reads emulator memory — this client isn't attached to a core or ROM.
+static uint32_t oe_ra_login_read_memory(uint32_t address, uint8_t *buffer,
+                                         uint32_t num_bytes, rc_client_t *client)
+{
+    (void)address; (void)buffer; (void)num_bytes; (void)client;
+    return 0;
+}
+
+static void oe_ra_login_callback(int result, const char *error_message,
+                                  rc_client_t *client, void *userdata)
+{
+    OERetroAchievementsLoginCompletion completion = (__bridge_transfer OERetroAchievementsLoginCompletion)userdata;
+
+    NSString *token = nil;
+    NSString *displayName = nil;
+    NSError *error = nil;
+
+    if (result == RC_OK) {
+        const rc_client_user_t *user = rc_client_get_user_info(client);
+        if (user && user->token && user->token[0] != '\0') {
+            token = @(user->token);
+            displayName = user->display_name ? @(user->display_name) : nil;
+        } else {
+            error = [NSError errorWithDomain:OERetroAchievementsLoginErrorDomain
+                                         code:result
+                                     userInfo:@{NSLocalizedDescriptionKey: @"Login succeeded but RetroAchievements returned no token."}];
+        }
+    } else {
+        NSString *message = (error_message && error_message[0] != '\0')
+            ? @(error_message)
+            : @"Invalid user/password combination.";
+        error = [NSError errorWithDomain:OERetroAchievementsLoginErrorDomain
+                                     code:result
+                                 userInfo:@{NSLocalizedDescriptionKey: message}];
+    }
+
+    rc_client_destroy(client);
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(token, displayName, error);
+    });
+}
+
+@implementation OERetroAchievementsLoginClient
+
++ (void)loginWithUsername:(NSString *)username
+                  password:(NSString *)password
+                completion:(OERetroAchievementsLoginCompletion)completion
+{
+    rc_client_t *client = rc_client_create(oe_ra_login_read_memory, oeRetroAchievementsServerCall);
+
+    OERetroAchievementsLoginCompletion completionCopy = [completion copy];
+    void *userdata = (__bridge_retained void *)completionCopy;
+
+    rc_client_begin_login_with_password(client, username.UTF8String, password.UTF8String,
+                                         oe_ra_login_callback, userdata);
+}
+
+@end


### PR DESCRIPTION
## What does this PR do?

Replaces the Achievements preferences pane's hand-rolled login request with the same proven `rc_client` transport that every in-game RA session already uses successfully. The old `RetroAchievementsAPI.login()` sent credentials as a GET request with a generic User-Agent straight to `dorequest.php` — a separate, fragile reimplementation that has now produced false-negative "Invalid user/password combination" errors for valid credentials twice (see `64ee63db8` / #657 for the first).

`oeRetroAchievementsServerCall` (used by every core's `rc_client_create(...)` call) POSTs with an RA-compliant User-Agent and already works correctly. Adds `OERetroAchievementsLoginClient`, a small standalone wrapper around `rc_client_create` + `rc_client_begin_login_with_password` using that same transport, and wires the sign-in flow to it. Removes the now-unused hand-rolled `RetroAchievementsAPI` enum.

The "Connect key" / API-key question raised in the issue thread was a red herring — no API key is needed for password login; the bug was transport-level (GET vs POST, non-compliant User-Agent), not credential-type confusion.

## What did you test?

`./Scripts/verify.sh --launch` (build, static analyzer, plist lint, codesign all pass). Manually tested the new login path end-to-end in Preferences → Achievements with intentionally wrong credentials and confirmed the request now round-trips to RetroAchievements' real server and surfaces their actual rejection message ("Invalid user/password combination. Please try again.") rather than failing locally — proving the POST transport works. Also confirmed the Sign In button re-enables after a failed attempt.

**This still needs a pass with a real RetroAchievements account to confirm a valid login succeeds and stores a working token** — I don't have one to test with. @nickybmon, could you verify sign-in with real credentials before merging?

## Which cores or systems are affected?

None — general app change (RetroAchievements login only). The token-based re-auth path used by in-game sessions is untouched.

## Did you use AI tools?

Used Claude to draft the fix, reviewed and partially verified it myself; final credential-based verification still needed.

## Linked issues

Fixes #644

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh --launch`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files include the BSD 2-Clause license header