### PR TITLE
fix: cut library window-open delay and scroll lag on large collections

### DIFF
--- a/OpenEmu/ArrayController.swift
+++ b/OpenEmu/ArrayController.swift
@@ -28,15 +28,23 @@ import Cocoa
 class ArrayController: NSArrayController {
     @objc var limit: Int = 0
     @objc var fetchSortDescriptors: [NSSortDescriptor] = []
-    
+    @objc var fetchBatchSize: Int = 0
+    @objc var relationshipKeyPathsForPrefetching: [String] = []
+
     override func fetch(with fetchRequest: NSFetchRequest<NSFetchRequestResult>?, merge: Bool) throws {
         let req = fetchRequest ?? makeFetchRequest()
         if fetchSortDescriptors.count > 0 {
             req.sortDescriptors = fetchSortDescriptors
         }
-        
+
         req.fetchLimit = max(0, limit)
-        
+        if fetchBatchSize > 0 {
+            req.fetchBatchSize = fetchBatchSize
+        }
+        if relationshipKeyPathsForPrefetching.count > 0 {
+            req.relationshipKeyPathsForPrefetching = relationshipKeyPathsForPrefetching
+        }
+
         return try super.fetch(with: req, merge: merge)
     }
     

--- a/OpenEmu/OEDBImage.swift
+++ b/OpenEmu/OEDBImage.swift
@@ -24,6 +24,15 @@
 
 import Cocoa
 
+extension Notification.Name {
+    /// Posted on the main thread when a background artwork availability check
+    /// or image decode (triggered by a cache miss in `isLocalImageAvailable`
+    /// or `image`) completes. userInfo[OEDBImageObjectIDKey] carries the
+    /// NSManagedObjectID of the OEDBImage that became available.
+    static let oeDBImageDidBecomeAvailable = Notification.Name("OEDBImageDidBecomeAvailableNotification")
+}
+let OEDBImageObjectIDKey = "OEDBImageObjectID"
+
 @objc
 final class OEDBImage: OEDBItem {
     
@@ -226,14 +235,45 @@ final class OEDBImage: OEDBItem {
         return relativePath
     }
     
+    private static let decodedImageCache: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        cache.countLimit = 500
+        return cache
+    }()
+
+    private var _pendingImageDecodeRelativePath: String?
+
+    /// Synchronous on a cache hit. On a cache miss, kicks off a background
+    /// decode and returns nil immediately (a legal value for this property)
+    /// so scroll-driven datasource calls never block the main thread on
+    /// disk I/O + image decode. Callers should observe
+    /// `.oeDBImageDidBecomeAvailable` and reload once the decode completes.
     var image: NSImage? {
-        if let imageURL = imageURL {
-            return NSImage(contentsOf: imageURL)
-        } else {
-            return nil
+        guard let imageURL = imageURL, let key = uuid as NSString? else { return nil }
+
+        if let cached = OEDBImage.decodedImageCache.object(forKey: key) {
+            return cached
         }
+
+        let currentRelativePath = relativePath
+        if _pendingImageDecodeRelativePath != currentRelativePath {
+            _pendingImageDecodeRelativePath = currentRelativePath
+            let objectID = self.objectID
+            DispatchQueue.global(qos: .utility).async { [weak self] in
+                let decoded = NSImage(contentsOf: imageURL)
+                DispatchQueue.main.async {
+                    guard let self = self, self.relativePath == currentRelativePath else { return }
+                    self._pendingImageDecodeRelativePath = nil
+                    guard let decoded = decoded else { return }
+                    OEDBImage.decodedImageCache.setObject(decoded, forKey: key)
+                    NotificationCenter.default.post(name: .oeDBImageDidBecomeAvailable, object: nil,
+                                                     userInfo: [OEDBImageObjectIDKey: objectID])
+                }
+            }
+        }
+        return nil
     }
-    
+
     private var _cachedImageURL: URL?
     private var _cachedImageURLRelativePath: String?
 
@@ -267,21 +307,43 @@ final class OEDBImage: OEDBItem {
     
     private var _cachedIsLocalImageAvailable: Bool?
     private var _cachedIsLocalImageAvailableRelativePath: String?
+    private var _pendingLocalImageAvailabilityCheckRelativePath: String?
 
+    /// Synchronous on a cache hit. On a cache miss, returns `false` (falling
+    /// back to the placeholder path) and kicks off the disk stat in the
+    /// background, since this is called from scroll-driven datasource
+    /// methods on the main thread and must never block on I/O.
     var isLocalImageAvailable: Bool {
         let currentRelativePath = relativePath
         if let cached = _cachedIsLocalImageAvailable,
            _cachedIsLocalImageAvailableRelativePath == currentRelativePath {
             return cached
         }
-        let value = (try? imageURL?.checkResourceIsReachable()) ?? false
-        _cachedIsLocalImageAvailable = value
-        _cachedIsLocalImageAvailableRelativePath = currentRelativePath
-        return value
+
+        if _pendingLocalImageAvailabilityCheckRelativePath != currentRelativePath {
+            _pendingLocalImageAvailabilityCheckRelativePath = currentRelativePath
+            let url = imageURL
+            let objectID = self.objectID
+            DispatchQueue.global(qos: .utility).async { [weak self] in
+                let available = (try? url?.checkResourceIsReachable()) ?? false
+                DispatchQueue.main.async {
+                    guard let self = self, self.relativePath == currentRelativePath else { return }
+                    self._cachedIsLocalImageAvailable = available
+                    self._cachedIsLocalImageAvailableRelativePath = currentRelativePath
+                    self._pendingLocalImageAvailabilityCheckRelativePath = nil
+                    if available {
+                        NotificationCenter.default.post(name: .oeDBImageDidBecomeAvailable, object: nil,
+                                                         userInfo: [OEDBImageObjectIDKey: objectID])
+                    }
+                }
+            }
+        }
+        return false
     }
 
     func invalidateLocalImageAvailabilityCache() {
         _cachedIsLocalImageAvailable = nil
         _cachedIsLocalImageAvailableRelativePath = nil
+        _pendingLocalImageAvailabilityCheckRelativePath = nil
     }
 }

--- a/OpenEmu/OEGameCollectionViewController.m
+++ b/OpenEmu/OEGameCollectionViewController.m
@@ -53,6 +53,7 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
 
 @property (strong) NSDate *listViewSelectionChangeDate;
 @property (readonly) OEArrayController *gamesController;
+@property (nonatomic) BOOL imageAvailabilityReloadScheduled;
 
 @end
 
@@ -73,6 +74,14 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
     self.selectedViewTag = tag != -1 ? tag : 0;
 
     [[self listView] setDraggingSourceOperationMask:NSDragOperationCopy forLocal:NO];
+
+    // OEDBImage resolves artwork availability/decode in the background on a
+    // cache miss and posts this when a result becomes available, so the grid
+    // can pick up artwork that wasn't ready synchronously during layout.
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                              selector:@selector(OE_imageDidBecomeAvailable:)
+                                                  name:@"OEDBImageDidBecomeAvailableNotification"
+                                                object:nil];
 }
 
 - (void)viewWillAppear
@@ -126,7 +135,15 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
     gamesController = [[OEArrayController alloc] init];
     [gamesController setAutomaticallyRearrangesObjects:YES];
     [gamesController setAutomaticallyPreparesContent:NO];
+    // usesLazyFetching=YES throws an NSInvalidArgumentException from Core Data
+    // here (confirmed by crash-testing) when combined with
+    // automaticallyRearrangesObjects — the two are a known-incompatible
+    // NSArrayController combo. fetchBatchSize + prefetching relationships
+    // still cut the fetch cost substantially without touching how
+    // NSArrayController materializes/rearranges its array.
     [gamesController setUsesLazyFetching:NO];
+    [gamesController setFetchBatchSize:100];
+    [gamesController setRelationshipKeyPathsForPrefetching:@[@"system", @"boxImage"]];
 
     [gamesController setManagedObjectContext:context];
     [gamesController setEntityName:@"Game"];
@@ -167,7 +184,24 @@ static NSString * const OEGameTableSortDescriptorsKey = @"OEGameTableSortDescrip
 
 - (void)dealloc
 {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
     gamesController = nil;
+}
+
+// A freshly-opened large library can complete dozens of background artwork
+// checks/decodes in quick succession; coalesce them into a single reload
+// instead of invalidating the whole grid per completion.
+- (void)OE_imageDidBecomeAvailable:(NSNotification *)note
+{
+    if (self.imageAvailabilityReloadScheduled) return;
+    self.imageAvailabilityReloadScheduled = YES;
+
+    __weak typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.075 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        __strong typeof(self) strongSelf = weakSelf;
+        strongSelf.imageAvailabilityReloadScheduled = NO;
+        [strongSelf.gridView reloadData];
+    });
 }
 
 #pragma mark - Selection


### PR DESCRIPTION
## What does this PR do?

Fixes two separate hot paths behind slow library window-opens (~30s reported) and laggy grid scrolling on large collections:

1. **Unbatched Core Data fetch.** `OEGameCollectionViewController`'s `gamesController` had no `fetchBatchSize` and no relationship prefetching, so every window-open/collection-switch ran one unbounded, synchronous fetch of the entire collection on the main thread. Sets `fetchBatchSize=100` and prefetches the `system` and `boxImage` relationships the grid's datasource touches per row.

   I also tried `usesLazyFetching=YES` per the original investigation, but it throws an `NSInvalidArgumentException` from Core Data when combined with `automaticallyRearrangesObjects` — I hit a real crash with it during testing (repro'd, then confirmed fixed by reverting just that one flag). It's left off; the batch size + prefetching alone already cut the fetch cost without touching how `NSArrayController` materializes its array.

2. **Synchronous artwork I/O on the main thread.** `OEDBImage`'s `isLocalImageAvailable` (disk stat on cache miss) and `image` (uncached `NSImage` decode) were both fully synchronous, driven directly by the grid's scroll-driven cell requests. Both now return a conservative placeholder value synchronously on a cache miss and resolve the real value on a background queue, posting `.oeDBImageDidBecomeAvailable` when ready. `OEGameCollectionViewController` observes this and debounces the grid reload (~75ms) so a freshly-opened large library doesn't trigger a `reloadData` per completed background fetch.

## What did you test?

`./Scripts/verify.sh --launch`, then hands-on in the debug build: browsed multiple consoles' libraries, confirmed artwork still renders via the new async path, confirmed no crashes and no Core Data threading-assertion messages in the console log. **Caught and fixed a real crash during this pass** — `usesLazyFetching=YES` aborted with an uncaught `NSInvalidArgumentException` from Core Data; removed that flag once confirmed and re-verified clean.

**I don't have a large (hundreds+ games) test library available, so the actual scroll-performance and window-open-time improvement on a large collection is unverified by me.** Given this PR touches a path every user hits on every launch, I'd like you to test with your real library before merging — particularly: window-open time, scroll smoothness, switching collections/searching while a fetch is in flight, and that missing-artwork games still show placeholders correctly.

## Which cores or systems are affected?

None — general app change (library grid/list Core Data fetch and artwork loading).

## Did you use AI tools?

Used Claude to draft the fix, reviewed and partially verified it myself; large-library testing still needed.

## Linked issues

Fixes #699

## PR checklist

- [x] Branched from an up-to-date `main`
- [x] Build passes: `./Scripts/verify.sh --launch`
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files