### PR TITLE
chore: add CODEOWNERS and pin third-party Actions to commit SHAs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @OpenEmu-Silicon/admins

--- a/.github/workflows/appcast-version-lint.yml
+++ b/.github/workflows/appcast-version-lint.yml
@@ -26,10 +26,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Check vendored core externals are populated
         run: ./Scripts/check-core-sources.sh
@@ -32,7 +32,7 @@ jobs:
       cores: ${{ steps.detect.outputs.cores }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
           fetch-depth: 0
 
@@ -100,10 +100,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1.6.0
         with:
           xcode-version: latest-stable
 
@@ -147,10 +147,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1.6.0
         with:
           xcode-version: latest-stable
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,17 +24,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
           submodules: recursive
 
       - name: Set Xcode version
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1.6.0
         with:
           xcode-version: latest-stable
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@6d786de4d6f3531a740e445b53a42b622bbbace8 # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: manual
@@ -57,6 +57,6 @@ jobs:
             CODE_SIGNING_REQUIRED=NO
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@6d786de4d6f3531a740e445b53a42b622bbbace8 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/openemu.yml
+++ b/.github/workflows/openemu.yml
@@ -10,11 +10,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
           submodules: recursive
       - name: Set Xcode version
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1.6.0
         with:
           xcode-version: latest-stable
       - name: Generate credentials stubs
@@ -35,13 +35,13 @@ jobs:
         run: ditto -c -k --keepParent OpenEmu.app OpenEmu-experimental.zip
       - name: Upload OpenEmu
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: OpenEmu.zip
           path: ${{github.workspace}}/DerivedData/Build/Products/Release/OpenEmu.zip
       - name: Upload OpenEmu Experimental
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: OpenEmu-experimental.zip
           path: ${{github.workspace}}/DerivedData/Build/Products/Release/OpenEmu-experimental.zip

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/xadmaster.yml
+++ b/.github/workflows/xadmaster.yml
@@ -10,14 +10,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
           submodules: recursive
       - name: Create build directory
         working-directory: ${{github.workspace}}
         run: mkdir build
       - name: Set Xcode version
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1.6.0
         with:
           xcode-version: 13.4.1
       - name: Build
@@ -27,7 +27,7 @@ jobs:
         working-directory: ${{github.workspace}}/build/DerivedData/Build/Products/Release/
         run: zip -y -r XADMaster.zip XADMaster.framework UniversalDetector.framework
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: XADMaster.zip
           path: ${{github.workspace}}/build/DerivedData/Build/Products/Release/XADMaster.zip


### PR DESCRIPTION
## What does this PR do?

Part of the GitHub org/repo hardening pass: adds `.github/CODEOWNERS` (routes required code-owner review to `@OpenEmu-Silicon/admins`, now required by branch protection on `main`) and pins every third-party GitHub Action used in the workflows to a resolved commit SHA instead of a mutable tag, with the tag kept as a trailing comment. `dependabot.yml` already tracks the `github-actions` ecosystem so it will keep the SHAs current going forward.

## What did you test?

No app code changed. Confirmed `gh pr checks` on a recent merged PR to identify the real required status-check context names before touching branch protection separately (not part of this diff). Workflow YAML syntax not otherwise exercised locally — CI on this PR will validate it.

## Which cores or systems are affected?

None — repo/CI configuration only, no app or core code touched.

## Did you use AI tools?

Used Claude Code to implement a GitHub org/repo hardening handoff doc: created CODEOWNERS, resolved and pinned Action tags to commit SHAs across all workflow files. Reviewed before committing.

## Linked issues

Fixes #

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo OpenEmu-Silicon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [ ] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [ ] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [ ] New files (if any) include the BSD 2-Clause license header