### PR TITLE
fix: re-sign core plugins after rewriting their SUFeedURL

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -553,7 +553,20 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
                 plist["SUFeedURL"] = canonical
                 let newData = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
                 try newData.write(to: plistURL)
-                Self.resealPluginSignature(at: plugin)
+
+                guard Self.resealPluginSignature(at: plugin) else {
+                    // Re-signing failed — put the original plist back so this plugin's
+                    // SUFeedURL is still stale on the next launch and the loop above
+                    // (`if currentURL.hasPrefix(canonicalPrefix) { continue }`) doesn't
+                    // treat it as already handled. Without this, a plugin that failed to
+                    // re-sign here would be silently reported as refreshed and then
+                    // never retried, left permanently unloadable.
+                    try? data.write(to: plistURL)
+                    failed.append((plugin.lastPathComponent, "re-sign failed after SUFeedURL rewrite"))
+                    os_log(.error, log: .default, "SUFeedURL refresh: re-sign failed for %{public}@ — reverted plist so it retries next launch", plugin.lastPathComponent)
+                    continue
+                }
+
                 refreshed.append(plugin.deletingPathExtension().lastPathComponent)
                 os_log(.info, log: .default, "SUFeedURL refresh: rewrote %{public}@ to %{public}@", plugin.lastPathComponent, canonical)
             } catch {
@@ -575,7 +588,12 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
     /// on for freshly downloaded cores. This only downgrades trust for a plugin
     /// this code just modified; an untouched Developer-ID-signed plugin is left
     /// alone entirely.
-    private static func resealPluginSignature(at pluginURL: URL) {
+    ///
+    /// Returns whether the re-sign actually succeeded, so the caller can avoid
+    /// reporting a plugin as fixed — and marking its feed URL as no longer
+    /// stale — when it isn't.
+    @discardableResult
+    private static func resealPluginSignature(at pluginURL: URL) -> Bool {
         let sign = Process()
         sign.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
         sign.arguments = ["--force", "--sign", "-", pluginURL.path]
@@ -586,9 +604,12 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
             sign.waitUntilExit()
             if sign.terminationStatus != 0 {
                 os_log(.error, log: .default, "Re-sign after SUFeedURL refresh failed (status %d) for %{public}@", sign.terminationStatus, pluginURL.lastPathComponent)
+                return false
             }
+            return true
         } catch {
             os_log(.error, log: .default, "Failed to launch codesign after SUFeedURL refresh for %{public}@: %{public}@", pluginURL.lastPathComponent, error.localizedDescription)
+            return false
         }
     }
 

--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -498,9 +498,15 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
     ///
     /// Staleness is detected by prefix: any URL that doesn't start with
     /// `canonicalPrefix` is rewritten to `<prefix><lowercased-bundle-suffix>.xml`.
-    /// Only the plist is touched — the binary's signature is undisturbed and
-    /// the host's `disable-library-validation` entitlement covers any plugin
-    /// signature drift, so re-codesigning is not required.
+    ///
+    /// Rewriting the plist breaks the bundle's existing seal (Info.plist is part
+    /// of what codesign hashes), so each touched plugin is re-signed ad hoc
+    /// afterward. `disable-library-validation` only waives the "same signing
+    /// team" check — it does not let the OS load a bundle whose signature no
+    /// longer matches its own contents, so skipping this step leaves the core
+    /// unloadable (confirmed via a real crash: a plugin left in this state
+    /// fails `OECorePlugin.corePlugin(bundleAtURL:)`, which force-unwraps to nil
+    /// in `OpenEmuHelperApp.load(withStartupInfo:)`).
     fileprivate func refreshStaleCoreFeedURLs() {
         let canonicalPrefix = "https://raw.githubusercontent.com/OpenEmu-Silicon/OpenEmu-Silicon/main/Appcasts/"
         feedURLRefreshReport = ([], [])
@@ -547,6 +553,7 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
                 plist["SUFeedURL"] = canonical
                 let newData = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
                 try newData.write(to: plistURL)
+                Self.resealPluginSignature(at: plugin)
                 refreshed.append(plugin.deletingPathExtension().lastPathComponent)
                 os_log(.info, log: .default, "SUFeedURL refresh: rewrote %{public}@ to %{public}@", plugin.lastPathComponent, canonical)
             } catch {
@@ -557,6 +564,32 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
 
         feedURLRefreshReport = (refreshed, failed)
         os_log(.info, log: .default, "SUFeedURL refresh summary: refreshed=%{public}d failed=%{public}d", refreshed.count, failed.count)
+    }
+
+    /// Re-seals a plugin bundle after `refreshStaleCoreFeedURLs` has edited its
+    /// Info.plist in place. Runs synchronously and ad hoc (`-`) — a Developer-ID
+    /// re-sign would need the org's private signing key, which isn't present on
+    /// an end-user machine, and `disable-library-validation` (set on both the
+    /// host and the helper) is exactly the entitlement that already lets this
+    /// app load ad-hoc-signed plugins, the same mechanism `CoreDownload` relies
+    /// on for freshly downloaded cores. This only downgrades trust for a plugin
+    /// this code just modified; an untouched Developer-ID-signed plugin is left
+    /// alone entirely.
+    private static func resealPluginSignature(at pluginURL: URL) {
+        let sign = Process()
+        sign.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+        sign.arguments = ["--force", "--sign", "-", pluginURL.path]
+        sign.standardOutput = FileHandle.nullDevice
+        sign.standardError = FileHandle.nullDevice
+        do {
+            try sign.run()
+            sign.waitUntilExit()
+            if sign.terminationStatus != 0 {
+                os_log(.error, log: .default, "Re-sign after SUFeedURL refresh failed (status %d) for %{public}@", sign.terminationStatus, pluginURL.lastPathComponent)
+            }
+        } catch {
+            os_log(.error, log: .default, "Failed to launch codesign after SUFeedURL refresh for %{public}@: %{public}@", pluginURL.lastPathComponent, error.localizedDescription)
+        }
     }
 
     /// One-shot diagnostic written at startup so we can see what core plugins


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `refreshStaleCoreFeedURLs()` (runs on every app launch) rewrites each installed core plugin's `SUFeedURL` in its `Info.plist` but never re-signs the bundle afterward. Editing `Info.plist` invalidates the bundle's existing code signature — the old code assumed `disable-library-validation` covered this, but that entitlement only waives the same-signing-team check, not a genuinely broken signature. The result: any plugin whose feed URL needed migrating got its signature broken the next time the app launched, and silently failed to load the next time that core was actually used (`OECorePlugin.corePlugin(bundleAtURL:)` swallows the load error and returns nil, which `OpenEmuHelperApp.load(withStartupInfo:)` force-unwraps, crashing the helper process).

On the machine this was found on, this had already broken 25 of 27 installed cores.

The fix re-signs each plugin (ad hoc) immediately after its plist is rewritten. A second commit closes a gap an adversarial review caught in the first pass: if the re-sign itself ever fails, the code now reports that plugin as failed (not fixed) and restores its original `Info.plist` so it's still considered stale and gets retried on the next launch — the first version would have silently marked a failed plugin as fixed and left it permanently broken, since the staleness check that gates this whole repair path is keyed on the feed URL already looking up to date.

## What did you test?

- Reproduced the crash for real: launched a debug build against a set of installed cores with stale feed URLs, confirmed the signature broke on launch, confirmed loading a game with one of those cores crashed the helper process (symbolicated the crash report back to the force-unwrap in `OpenEmuHelperApp.load(withStartupInfo:)`).
- Applied the fix, rebuilt, relaunched, and confirmed all previously-broken cores that still needed migrating now come out correctly re-signed (`codesign --verify` passing) and load without crashing.
- Manually re-signed the cores that had already been broken by a prior run before the fix existed (the fix only prevents new breakage — it doesn't retroactively repair damage from before it landed, since the loop skips a plugin once its feed URL already looks canonical).
- Ran the project's `adversarial-reviewer` against the diff, which caught the failure-handling gap described above. Fixed it, rebuilt clean, and confirmed the build still passes.
- Did not induce an actual `codesign` failure to exercise the rollback path directly — that logic was verified by code review and by the adversarial review's reasoning, not by reproducing the failure live.

## Which cores or systems are affected?

None specifically — this is a general app-level fix (`OpenEmu/AppDelegate.swift`). It affects every installed core plugin, since the function that had the bug runs across all of them on every launch.

## Did you use AI tools?

Yes. Used Claude Code to investigate a crash report down to its root cause, write the fix, and run an adversarial review pass against the diff (which found a real gap in the first version, since fixed). Verified locally by hand: real crash reproduction, real rebuild/relaunch, and manual confirmation that every installed core came back to a valid signature.

## Linked issues

No existing issue — found and fixed in the same session it surfaced in.

---

## How to test locally

```bash
cd ~/Documents/Cursor/Open\ Emu
gh pr checkout NUMBER --repo OpenEmu-Silicon/OpenEmu-Silicon
./Scripts/verify.sh
./Scripts/launch-debug.sh
```

`verify.sh` builds, prunes stale DerivedData, and runs a codesign check. `launch-debug.sh` picks the freshest Debug build without using a glob (which opens multiple instances when DerivedData has more than one hash directory).

To see the original bug, you'd need a core plugin with a `SUFeedURL` that doesn't yet start with `https://raw.githubusercontent.com/OpenEmu-Silicon/OpenEmu-Silicon/main/Appcasts/` — most cores built from current `main` already carry the canonical URL, so a fresh install won't reproduce it. The fix itself is visible just by reading the diff: `resealPluginSignature(at:)` is called right after the plist rewrite, and its success/failure now gates whether the plugin is reported as fixed.

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
