### PR TITLE
Libretro Cheat Database Integration (expanded)

### DIFF
--- a/Mednafen/MednafenGameCore.mm
+++ b/Mednafen/MednafenGameCore.mm
@@ -74,6 +74,8 @@ extern "C" uint8_t *MDFNWS_GetRAMPointer(void);
 extern "C" uint32_t MDFNWS_GetRAMSize(void);
 extern "C" uint8_t *MDFNWS_GetSRAMPointer(void);
 extern "C" uint32_t MDFNWS_GetSRAMSize(void);
+extern "C" uint8_t *MDFNWS_GetROMPointer(void);
+extern "C" uint32_t MDFNWS_GetROMSize(void);
 
 #ifdef DEBUG
     #error "Cores should not be compiled in DEBUG! Follow the guide https://github.com/OpenEmu/OpenEmu/wiki/Compiling-From-Source-Guide"
@@ -130,6 +132,10 @@ static const uint32_t kLynxRAWarmupFrames = 150;
     NSString *_romPath;
     int _rcConsole;
     NSMutableDictionary<NSString *, NSNumber *> *_cheatList;
+    // wswan ROM-patch cheats only: cheat code -> {rom offset: original byte}, so disabling a code
+    // can revert exactly the bytes it touched. wsCartROM isn't a mempatcher page, so unlike RAM
+    // 'R' patches, nothing else puts these bytes back once written.
+    NSMutableDictionary<NSString *, NSMutableDictionary<NSNumber *, NSNumber *> *> *_romPatchBackups;
     BOOL _isSystemPCECD;
     uint32_t _lynxFrameCount;
     // Owned C-string copy of the active console module name (e.g. "psx", "pce").
@@ -4368,10 +4374,23 @@ namespace Mednafen { void MDFN_FlushGameCheats(int nosave); }
     if (!_cheatList)
         _cheatList = [NSMutableDictionary dictionary];
 
-    if (enabled)
+    if (enabled) {
         _cheatList[code] = @YES;
-    else
+    } else {
         [_cheatList removeObjectForKey:code];
+
+        // ROM patches persist in wsCartROM until reverted here; unlike RAM 'R' patches, simply
+        // no longer re-asserting them (via MDFN_FlushGameCheats below) doesn't undo them.
+        NSMutableDictionary<NSNumber *, NSNumber *> *romBackups = _romPatchBackups[code];
+        if (romBackups) {
+            uint8_t *rom = MDFNWS_GetROMPointer();
+            if (rom) {
+                for (NSNumber *offsetKey in romBackups)
+                    rom[offsetKey.unsignedIntValue] = romBackups[offsetKey].unsignedCharValue;
+            }
+            [_romPatchBackups removeObjectForKey:code];
+        }
+    }
 
     Mednafen::MDFN_FlushGameCheats(1);
 
@@ -4403,6 +4422,29 @@ namespace Mednafen { void MDFN_FlushGameCheats(int nosave); }
                     uint32_t page = (addr >> 16) & 0xFF;
                     uint32_t offset = addr & 0x1FFF;
                     addr = (page << 13) | offset;
+                }
+
+                // WonderSwan ROM code patch (GameHacking.org convention: 0x4000000 | ROM file offset).
+                // wsCartROM isn't a mempatcher page, so this bypasses MDFNI_AddCheat and writes the
+                // buffer directly; see the disable branch above for the revert side.
+                if ([_mednafenCoreModule isEqualToString:@"wswan"] && (addr & 0x04000000)) {
+                    uint32_t romOffset = addr & 0x03FFFFFF;
+                    uint8_t *rom = MDFNWS_GetROMPointer();
+                    uint32_t romSize = MDFNWS_GetROMSize();
+                    if (rom && romOffset < romSize) {
+                        if (!_romPatchBackups)
+                            _romPatchBackups = [NSMutableDictionary dictionary];
+                        NSMutableDictionary<NSNumber *, NSNumber *> *backups = _romPatchBackups[key];
+                        if (!backups) {
+                            backups = [NSMutableDictionary dictionary];
+                            _romPatchBackups[key] = backups;
+                        }
+                        NSNumber *offsetKey = @(romOffset);
+                        if (!backups[offsetKey])
+                            backups[offsetKey] = @(rom[romOffset]);
+                        rom[romOffset] = (uint8_t)(val & 0xFF);
+                    }
+                    continue;
                 }
 
                 patch.addr = addr;

--- a/Mednafen/mednafen/wswan/memory.cpp
+++ b/Mednafen/mednafen/wswan/memory.cpp
@@ -901,3 +901,6 @@ extern "C" uint8_t *MDFNWS_GetRAMPointer(void) { return MDFN_IEN_WSWAN::wsRAM; }
 extern "C" uint32_t MDFNWS_GetRAMSize(void) { return MDFN_IEN_WSWAN::wsRAMSize; }
 extern "C" uint8_t *MDFNWS_GetSRAMPointer(void) { return MDFN_IEN_WSWAN::wsSRAM; }
 extern "C" uint32_t MDFNWS_GetSRAMSize(void) { return MDFN_IEN_WSWAN::sram_size; }
+// Not a mempatcher page (ROM isn't registered via MDFNMP_AddRAM); setCheat: pokes this buffer directly for ROM-patch cheats.
+extern "C" uint8_t *MDFNWS_GetROMPointer(void) { return MDFN_IEN_WSWAN::wsCartROM; }
+extern "C" uint32_t MDFNWS_GetROMSize(void) { return MDFN_IEN_WSWAN::rom_size; }

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
@@ -46,6 +46,7 @@ extern NSString *const OESystemIdentifierColecoVision;
 extern NSString *const OESystemIdentifierSegaCD;
 extern NSString *const OESystemIdentifierSega32X;
 extern NSString *const OESystemIdentifierAtari2600;
+extern NSString *const OESystemIdentifierLynx;
 extern NSString *const OESystemIdentifierPSX;
 extern NSString *const OESystemIdentifierSaturn;
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
@@ -54,6 +54,7 @@ extern NSString *const OESystemIdentifierPSX;
 extern NSString *const OESystemIdentifierSaturn;
 extern NSString *const OESystemIdentifierVB;
 extern NSString *const OESystemIdentifierWS;
+extern NSString *const OESystemIdentifierPCFX;
 
 // MARK: - Cheat Code Type Strings
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
@@ -47,6 +47,7 @@ extern NSString *const OESystemIdentifierSegaCD;
 extern NSString *const OESystemIdentifierSega32X;
 extern NSString *const OESystemIdentifierAtari2600;
 extern NSString *const OESystemIdentifierLynx;
+extern NSString *const OESystemIdentifierNGP;
 extern NSString *const OESystemIdentifierPSX;
 extern NSString *const OESystemIdentifierSaturn;
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
@@ -52,6 +52,7 @@ extern NSString *const OESystemIdentifierPCE;
 extern NSString *const OESystemIdentifierPCECD;
 extern NSString *const OESystemIdentifierPSX;
 extern NSString *const OESystemIdentifierSaturn;
+extern NSString *const OESystemIdentifierVB;
 
 // MARK: - Cheat Code Type Strings
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
@@ -48,6 +48,7 @@ extern NSString *const OESystemIdentifierSega32X;
 extern NSString *const OESystemIdentifierAtari2600;
 extern NSString *const OESystemIdentifierLynx;
 extern NSString *const OESystemIdentifierNGP;
+extern NSString *const OESystemIdentifierPCE;
 extern NSString *const OESystemIdentifierPSX;
 extern NSString *const OESystemIdentifierSaturn;
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
@@ -49,6 +49,7 @@ extern NSString *const OESystemIdentifierAtari2600;
 extern NSString *const OESystemIdentifierLynx;
 extern NSString *const OESystemIdentifierNGP;
 extern NSString *const OESystemIdentifierPCE;
+extern NSString *const OESystemIdentifierPCECD;
 extern NSString *const OESystemIdentifierPSX;
 extern NSString *const OESystemIdentifierSaturn;
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.h
@@ -53,6 +53,7 @@ extern NSString *const OESystemIdentifierPCECD;
 extern NSString *const OESystemIdentifierPSX;
 extern NSString *const OESystemIdentifierSaturn;
 extern NSString *const OESystemIdentifierVB;
+extern NSString *const OESystemIdentifierWS;
 
 // MARK: - Cheat Code Type Strings
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
@@ -50,6 +50,7 @@ NSString *const OESystemIdentifierPCE        = @"openemu.system.pce";
 NSString *const OESystemIdentifierPCECD      = @"openemu.system.pcecd";
 NSString *const OESystemIdentifierPSX        = @"openemu.system.psx";
 NSString *const OESystemIdentifierSaturn     = @"openemu.system.saturn";
+NSString *const OESystemIdentifierVB         = @"openemu.system.vb";
 
 // MARK: - Cheat Code Type Strings
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
@@ -51,6 +51,7 @@ NSString *const OESystemIdentifierPCECD      = @"openemu.system.pcecd";
 NSString *const OESystemIdentifierPSX        = @"openemu.system.psx";
 NSString *const OESystemIdentifierSaturn     = @"openemu.system.saturn";
 NSString *const OESystemIdentifierVB         = @"openemu.system.vb";
+NSString *const OESystemIdentifierWS         = @"openemu.system.ws";
 
 // MARK: - Cheat Code Type Strings
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
@@ -46,6 +46,7 @@ NSString *const OESystemIdentifierSega32X    = @"openemu.system.32x";
 NSString *const OESystemIdentifierAtari2600  = @"openemu.system.2600";
 NSString *const OESystemIdentifierLynx       = @"openemu.system.lynx";
 NSString *const OESystemIdentifierNGP        = @"openemu.system.ngp";
+NSString *const OESystemIdentifierPCE        = @"openemu.system.pce";
 NSString *const OESystemIdentifierPSX        = @"openemu.system.psx";
 NSString *const OESystemIdentifierSaturn     = @"openemu.system.saturn";
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
@@ -45,6 +45,7 @@ NSString *const OESystemIdentifierSegaCD     = @"openemu.system.scd";
 NSString *const OESystemIdentifierSega32X    = @"openemu.system.32x";
 NSString *const OESystemIdentifierAtari2600  = @"openemu.system.2600";
 NSString *const OESystemIdentifierLynx       = @"openemu.system.lynx";
+NSString *const OESystemIdentifierNGP        = @"openemu.system.ngp";
 NSString *const OESystemIdentifierPSX        = @"openemu.system.psx";
 NSString *const OESystemIdentifierSaturn     = @"openemu.system.saturn";
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
@@ -47,6 +47,7 @@ NSString *const OESystemIdentifierAtari2600  = @"openemu.system.2600";
 NSString *const OESystemIdentifierLynx       = @"openemu.system.lynx";
 NSString *const OESystemIdentifierNGP        = @"openemu.system.ngp";
 NSString *const OESystemIdentifierPCE        = @"openemu.system.pce";
+NSString *const OESystemIdentifierPCECD      = @"openemu.system.pcecd";
 NSString *const OESystemIdentifierPSX        = @"openemu.system.psx";
 NSString *const OESystemIdentifierSaturn     = @"openemu.system.saturn";
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
@@ -44,6 +44,7 @@ NSString *const OESystemIdentifierColecoVision = @"openemu.system.colecovision";
 NSString *const OESystemIdentifierSegaCD     = @"openemu.system.scd";
 NSString *const OESystemIdentifierSega32X    = @"openemu.system.32x";
 NSString *const OESystemIdentifierAtari2600  = @"openemu.system.2600";
+NSString *const OESystemIdentifierLynx       = @"openemu.system.lynx";
 NSString *const OESystemIdentifierPSX        = @"openemu.system.psx";
 NSString *const OESystemIdentifierSaturn     = @"openemu.system.saturn";
 

--- a/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
+++ b/OpenEmu-SDK/OpenEmuBase/OESystemConstants.m
@@ -52,6 +52,7 @@ NSString *const OESystemIdentifierPSX        = @"openemu.system.psx";
 NSString *const OESystemIdentifierSaturn     = @"openemu.system.saturn";
 NSString *const OESystemIdentifierVB         = @"openemu.system.vb";
 NSString *const OESystemIdentifierWS         = @"openemu.system.ws";
+NSString *const OESystemIdentifierPCFX       = @"openemu.system.pcfx";
 
 // MARK: - Cheat Code Type Strings
 

--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -230,6 +230,11 @@ class AppDelegate: NSObject, UNUserNotificationCenterDelegate {
             
             assert(OELibraryDatabase.default != nil, "No database available!")
             
+            // Must run before any game can load (and so before Browse Online Cheats can open),
+            // so the cached cheat databases on disk still reflect whatever produced the existing
+            // feedback entries, before this session gets a chance to refresh them.
+            CheatFeedbackService.shared.migrateIfNeeded()
+            
             DispatchQueue.main.async {
                 NotificationCenter.default.post(name: .libraryDidLoad, object: OELibraryDatabase.default!)
             }

--- a/OpenEmu/BrowseOnlineCheatsViewController.swift
+++ b/OpenEmu/BrowseOnlineCheatsViewController.swift
@@ -1031,7 +1031,7 @@ extension BrowseOnlineCheatsViewController: NSTableViewDelegate {
         let row = resultsTableView.row(for: sender)
         guard row >= 0, row < visibleCheats.count else { return }
         let cheat = visibleCheats[row]
-        log.debug("rawCode for '\(cheat.name, privacy: .public)': \(cheat.rawCode, privacy: .public)")
+        // log.debug("rawCode for '\(cheat.name, privacy: .public)': \(cheat.rawCode, privacy: .public)")
         presentCodeDialog(for: cheat)
     }
 

--- a/OpenEmu/BrowseOnlineCheatsViewController.swift
+++ b/OpenEmu/BrowseOnlineCheatsViewController.swift
@@ -24,6 +24,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Cocoa
+import OpenEmuKit
 import os.log
 
 private let log = Logger(subsystem: "org.openemu.OpenEmu", category: "BrowseOnlineCheatsViewController")
@@ -1099,7 +1100,11 @@ extension BrowseOnlineCheatsViewController: NSTableViewDelegate {
                                                 systemIdentifier: document.systemPlugin.systemIdentifier,
                                                 coreIdentifier: document.corePlugin.bundleIdentifier,
                                                 coreVersion: document.corePlugin.version,
-                                                rawCode: cheat.rawCode)
+                                                rawCode: cheat.rawCode,
+                                                provider: cheat.providerName,
+                                                gameName: document.rom.game?.displayName,
+                                                serial: document.rom.serial,
+                                                raHash: document.retroAchievementsSessionInfo?[OERetroAchievementsGameHashKey] as? String)
 
             if let feedback {
                 CheatFeedbackService.shared.setStatus(feedback,
@@ -1108,7 +1113,11 @@ extension BrowseOnlineCheatsViewController: NSTableViewDelegate {
                                                      systemIdentifier: document.systemPlugin.systemIdentifier,
                                                      coreIdentifier: document.corePlugin.bundleIdentifier,
                                                      coreVersion: document.corePlugin.version,
-                                                     rawCode: cheat.rawCode)
+                                                     rawCode: cheat.rawCode,
+                                                     provider: cheat.providerName,
+                                                     gameName: document.rom.game?.displayName,
+                                                     serial: document.rom.serial,
+                                                     raHash: document.retroAchievementsSessionInfo?[OERetroAchievementsGameHashKey] as? String)
                 statuses[key] = feedback
             }
         }
@@ -1237,7 +1246,11 @@ extension BrowseOnlineCheatsViewController: NSTableViewDelegate {
                                                  systemIdentifier: document.systemPlugin.systemIdentifier,
                                                  coreIdentifier: document.corePlugin.bundleIdentifier,
                                                  coreVersion: document.corePlugin.version,
-                                                 rawCode: cheat.rawCode)
+                                                 rawCode: cheat.rawCode,
+                                                 provider: cheat.providerName,
+                                                 gameName: document.rom.game?.displayName,
+                                                 serial: document.rom.serial,
+                                                 raHash: document.retroAchievementsSessionInfo?[OERetroAchievementsGameHashKey] as? String)
         }
 
         // Re-filtered rather than redrawn: the new status may exclude this row.

--- a/OpenEmu/BrowseOnlineCheatsViewController.swift
+++ b/OpenEmu/BrowseOnlineCheatsViewController.swift
@@ -24,6 +24,9 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Cocoa
+import os.log
+
+private let log = Logger(subsystem: "org.openemu.OpenEmu", category: "BrowseOnlineCheatsViewController")
 
 final class BrowseOnlineCheatsViewController: NSViewController {
 
@@ -722,7 +725,7 @@ final class BrowseOnlineCheatsViewController: NSViewController {
                                           comment: "Browse online cheats: disambiguates multiple cheats sharing the same name, e.g. \"99 Magic (2 of 7)\""),
                 cheat.name, index, total
             )
-            return DatabaseCheat(name: disambiguatedName, code: cheat.code, providerName: cheat.providerName)
+            return DatabaseCheat(name: disambiguatedName, code: cheat.code, providerName: cheat.providerName, rawCode: cheat.rawCode)
         }
     }
 
@@ -1026,7 +1029,9 @@ extension BrowseOnlineCheatsViewController: NSTableViewDelegate {
     @objc private func showCodeClicked(_ sender: NSButton) {
         let row = resultsTableView.row(for: sender)
         guard row >= 0, row < visibleCheats.count else { return }
-        presentCodeDialog(for: visibleCheats[row])
+        let cheat = visibleCheats[row]
+        log.debug("rawCode for '\(cheat.name, privacy: .public)': \(cheat.rawCode, privacy: .public)")
+        presentCodeDialog(for: cheat)
     }
 
     // MARK: - Notes Column
@@ -1093,7 +1098,8 @@ extension BrowseOnlineCheatsViewController: NSTableViewDelegate {
                                                 md5: md5,
                                                 systemIdentifier: document.systemPlugin.systemIdentifier,
                                                 coreIdentifier: document.corePlugin.bundleIdentifier,
-                                                coreVersion: document.corePlugin.version)
+                                                coreVersion: document.corePlugin.version,
+                                                rawCode: cheat.rawCode)
 
             if let feedback {
                 CheatFeedbackService.shared.setStatus(feedback,
@@ -1101,7 +1107,8 @@ extension BrowseOnlineCheatsViewController: NSTableViewDelegate {
                                                      md5: md5,
                                                      systemIdentifier: document.systemPlugin.systemIdentifier,
                                                      coreIdentifier: document.corePlugin.bundleIdentifier,
-                                                     coreVersion: document.corePlugin.version)
+                                                     coreVersion: document.corePlugin.version,
+                                                     rawCode: cheat.rawCode)
                 statuses[key] = feedback
             }
         }
@@ -1229,7 +1236,8 @@ extension BrowseOnlineCheatsViewController: NSTableViewDelegate {
                                                  md5: md5,
                                                  systemIdentifier: document.systemPlugin.systemIdentifier,
                                                  coreIdentifier: document.corePlugin.bundleIdentifier,
-                                                 coreVersion: document.corePlugin.version)
+                                                 coreVersion: document.corePlugin.version,
+                                                 rawCode: cheat.rawCode)
         }
 
         // Re-filtered rather than redrawn: the new status may exclude this row.
@@ -1288,7 +1296,7 @@ extension BrowseOnlineCheatsViewController: NSTableViewDelegate {
 
         switch state {
         case .notImported:
-            gameDocument?.addImportedCheat(code: cheat.code, name: cheat.name, providerName: cheat.providerName)
+            gameDocument?.addImportedCheat(code: cheat.code, name: cheat.name, providerName: cheat.providerName, rawCode: cheat.rawCode)
         case .importedByThisFeature:
             // Blocks on the "did it work" prompt, so statuses are re-read once it returns.
             gameDocument?.removeImportedCheat(code: cheat.code)

--- a/OpenEmu/CheatCodeValidator.swift
+++ b/OpenEmu/CheatCodeValidator.swift
@@ -95,6 +95,10 @@ enum CheatCodeValidator {
         case OESystemIdentifierGameGear, OESystemIdentifierSG1000:
             return isSMSGameGenieCode(code) || isSMSActionReplayCode(code) || isRawAddressValue(code)
 
+        case OESystemIdentifierPCE:
+            // Mednafen (pce module): paged (F8-FB) or linear (1F0000-1F7FFF) physical address, 1-byte value
+            return isPCECode(code)
+
         default:
             return true
         }
@@ -222,5 +226,20 @@ enum CheatCodeValidator {
         guard code.contains("-") else { return false }
         let parts = code.split(separator: "-")
         return parts.count == 2 && parts.allSatisfy { $0.count == 4 && $0.allSatisfy(\.isHexDigit) }
+    }
+
+    /// PCE (Mednafen): 6-hex address + 2-hex value, address must land in a real RAM window —
+    /// either the paged form (page F8-FB, slot offset 0x2000-0x3FFF, e.g. F82DBA:02) or the
+    /// linear physical form `setCheat` converts paged addresses into (0x1F0000-0x1F7FFF, e.g. 1F0083:02).
+    static func isPCECode(_ code: String) -> Bool {
+        guard isRawAddressValue(code, addressHexChars: 6, valueHexChars: 2),
+              let addr = UInt32(code.prefix(6), radix: 16)
+        else { return false }
+        let page = (addr >> 16) & 0xFF
+        let offset = addr & 0xFFFF
+        if (0xF8...0xFB).contains(page) && (0x2000...0x3FFF).contains(offset) {
+            return true
+        }
+        return (0x1F0000...0x1F7FFF).contains(addr)
     }
 }

--- a/OpenEmu/CheatCodeValidator.swift
+++ b/OpenEmu/CheatCodeValidator.swift
@@ -103,6 +103,10 @@ enum CheatCodeValidator {
             // Mednafen (pce module): paged (F8-FB) or linear (1F0000-1F7FFF) physical address, 1-byte value
             return isPCECode(code)
 
+        case OESystemIdentifierVB:
+            // Mednafen (vb module): no named format, only raw WRAM address:value (8 hex address + 2 hex value)
+            return isRawAddressValue(code, addressHexChars: 8, valueHexChars: 2)
+
         default:
             return true
         }

--- a/OpenEmu/CheatCodeValidator.swift
+++ b/OpenEmu/CheatCodeValidator.swift
@@ -69,6 +69,10 @@ enum CheatCodeValidator {
             // Mednafen: 12 hex (PSX GameShark) or raw address:value
             return isPSXGameSharkCode(code) || isRawAddressValue(code)
 
+        case OESystemIdentifierSaturn:
+            // Mednafen (ss module): 12 hex, type nibble 1 (word) or 3 (byte) only
+            return isSaturnActionReplayCode(code)
+
         case OESystemIdentifierGBA:
             // mGBA: 12 hex (CodeBreaker), 16 hex (GameShark/PAR v3), or VBA (address:value)
             return isGBACode(code)
@@ -171,6 +175,13 @@ enum CheatCodeValidator {
     /// PSX GameShark: exactly 12 hex characters (type byte + 24-bit address + 16-bit value)
     static func isPSXGameSharkCode(_ code: String) -> Bool {
         return code.count == 12 && code.allSatisfy(\.isHexDigit)
+    }
+
+    /// Saturn GameShark/Action Replay: 12 hex characters, type nibble 1 (word write) or 3 (byte
+    /// write) only — the only two operations Mednafen's `ss` cheat branch actually applies.
+    static func isSaturnActionReplayCode(_ code: String) -> Bool {
+        guard code.count == 12, code.allSatisfy(\.isHexDigit), let typeNibble = code.first else { return false }
+        return typeNibble == "1" || typeNibble == "3"
     }
 
     /// GBA code: 12 hex (CodeBreaker), 16 hex (GameShark/PAR v3), or VBA (8hex:value)

--- a/OpenEmu/CheatDatabaseService.swift
+++ b/OpenEmu/CheatDatabaseService.swift
@@ -34,6 +34,18 @@ struct DatabaseCheat: Sendable {
     let name: String
     let code: String
     let providerName: String
+    /// Unmodified text as published by the provider, before normalization. Not shown to the user;
+    /// carried through for future cheat feedback correlation. Mandatory: every provider reads from
+    /// some source text, even when that text equals `code` (e.g. `OpenEmuCheatProvider`, which
+    /// applies no normalization).
+    let rawCode: String
+
+    init(name: String, code: String, providerName: String, rawCode: String) {
+        self.name = name
+        self.code = code
+        self.providerName = providerName
+        self.rawCode = rawCode
+    }
 }
 
 /// A source of cheat codes for a given system and ROM.

--- a/OpenEmu/CheatFeedbackService.swift
+++ b/OpenEmu/CheatFeedbackService.swift
@@ -52,6 +52,10 @@ struct CheatFeedbackEntry: Codable, Sendable {
     let status: CheatFeedbackStatus?
     /// User-authored, freeform. `nil`/absent for existing files predating this field.
     var notes: String?
+    /// Unmodified text as published by the provider, before normalization. Not shown to the
+    /// user; kept so a future central feedback service can key on the upstream cheat rather
+    /// than on OpenEmu's own normalized encoding, which can change between versions.
+    var rawCode: String?
     let updatedAt: Date
 }
 
@@ -132,14 +136,15 @@ final class CheatFeedbackService {
                    md5: String,
                    systemIdentifier: String,
                    coreIdentifier: String,
-                   coreVersion: String) {
+                   coreVersion: String,
+                   rawCode: String? = nil) {
         let key = Self.key(for: code)
         var file = load(md5: md5, systemIdentifier: systemIdentifier)
             ?? CheatFeedbackFile(schemaVersion: Self.schemaVersion, md5: md5, entries: [])
 
-        let existingNotes = file.entries.first {
+        let existing = file.entries.first {
             $0.code == key && $0.coreIdentifier == coreIdentifier && $0.coreVersion == coreVersion
-        }?.notes
+        }
 
         file.entries.removeAll {
             $0.code == key && $0.coreIdentifier == coreIdentifier && $0.coreVersion == coreVersion
@@ -149,7 +154,8 @@ final class CheatFeedbackService {
                                                coreIdentifier: coreIdentifier,
                                                coreVersion: coreVersion,
                                                status: status,
-                                               notes: existingNotes,
+                                               notes: existing?.notes,
+                                               rawCode: rawCode ?? existing?.rawCode,
                                                updatedAt: Date()))
 
         save(file, md5: md5, systemIdentifier: systemIdentifier)
@@ -163,14 +169,15 @@ final class CheatFeedbackService {
                   md5: String,
                   systemIdentifier: String,
                   coreIdentifier: String,
-                  coreVersion: String) {
+                  coreVersion: String,
+                  rawCode: String? = nil) {
         let key = Self.key(for: code)
         var file = load(md5: md5, systemIdentifier: systemIdentifier)
             ?? CheatFeedbackFile(schemaVersion: Self.schemaVersion, md5: md5, entries: [])
 
-        let existingStatus = file.entries.first {
+        let existing = file.entries.first {
             $0.code == key && $0.coreIdentifier == coreIdentifier && $0.coreVersion == coreVersion
-        }?.status
+        }
 
         file.entries.removeAll {
             $0.code == key && $0.coreIdentifier == coreIdentifier && $0.coreVersion == coreVersion
@@ -180,12 +187,13 @@ final class CheatFeedbackService {
         let newNotes = (trimmed?.isEmpty ?? true) ? nil : trimmed
 
         // Don't persist an empty shell that has neither a status nor a note.
-        if existingStatus != nil || newNotes != nil {
+        if existing?.status != nil || newNotes != nil {
             file.entries.append(CheatFeedbackEntry(code: key,
                                                    coreIdentifier: coreIdentifier,
                                                    coreVersion: coreVersion,
-                                                   status: existingStatus,
+                                                   status: existing?.status,
                                                    notes: newNotes,
+                                                   rawCode: rawCode ?? existing?.rawCode,
                                                    updatedAt: Date()))
         }
 

--- a/OpenEmu/CheatFeedbackService.swift
+++ b/OpenEmu/CheatFeedbackService.swift
@@ -56,13 +56,36 @@ struct CheatFeedbackEntry: Codable, Sendable {
     /// user; kept so a future central feedback service can key on the upstream cheat rather
     /// than on OpenEmu's own normalized encoding, which can change between versions.
     var rawCode: String?
+    /// The `CheatDatabaseProvider.name` this code came from (e.g. "Libretro"). `nil` for
+    /// manual/Cheat Search entries, which have no upstream provider.
+    var provider: String?
     let updatedAt: Date
 }
 
 private struct CheatFeedbackFile: Codable {
     var schemaVersion: Int
     var md5: String
+    /// Kept alongside the folder structure so a file is self-describing if ever handled
+    /// independently of its `CheatFeedback/<systemIdentifier>/` location. Optional only so
+    /// files predating this field still decode; every write path fills it in from context.
+    var systemIdentifier: String?
+    /// Best-effort, for identifying the game if its MD5 no longer resolves (e.g. re-dumped ROM).
+    var gameName: String?
+    /// Cartridge/disc serial, a second fallback identifier alongside MD5 \u2014 same role it already
+    /// plays as a DAT lookup fallback in `LibretroCheatProvider`. Backfillable during migration
+    /// since it's already stored on the ROM in the library, independent of any game/core running.
+    var serial: String?
+    /// RetroAchievements' own per-console game hash. Unlike `serial`, this is computed inside the
+    /// core at runtime from the loaded ROM, so it can only ever be captured at write time \u2014 never
+    /// backfilled during migration, which runs before any game or core exists.
+    var raHash: String?
     var entries: [CheatFeedbackEntry]
+}
+
+/// Tracks whether the one-time file migration (see `CheatFeedbackService.migrateIfNeeded()`)
+/// has already run, so app startup doesn't re-walk every feedback file on every launch.
+private struct CheatFeedbackMigrationConfig: Codable {
+    var schemaVersion: Int
 }
 
 /// Stores the user's "does this cheat work" reports, separate from their cheat
@@ -75,7 +98,9 @@ final class CheatFeedbackService {
 
     static let shared = CheatFeedbackService()
 
-    private static let schemaVersion = 1
+    /// v2 added `rawCode`/`provider` per entry and `gameName`/`systemIdentifier` per file.
+    /// See `migrateIfNeeded()` for the one-time reconciliation of files predating this.
+    private static let schemaVersion = 2
 
     private let fileManager = FileManager.default
 
@@ -137,10 +162,18 @@ final class CheatFeedbackService {
                    systemIdentifier: String,
                    coreIdentifier: String,
                    coreVersion: String,
-                   rawCode: String? = nil) {
+                   rawCode: String? = nil,
+                   provider: String? = nil,
+                   gameName: String? = nil,
+                   serial: String? = nil,
+                   raHash: String? = nil) {
         let key = Self.key(for: code)
         var file = load(md5: md5, systemIdentifier: systemIdentifier)
-            ?? CheatFeedbackFile(schemaVersion: Self.schemaVersion, md5: md5, entries: [])
+            ?? CheatFeedbackFile(schemaVersion: Self.schemaVersion, md5: md5, systemIdentifier: systemIdentifier, gameName: gameName, serial: serial, raHash: raHash, entries: [])
+        file.systemIdentifier = systemIdentifier
+        file.gameName = gameName ?? file.gameName
+        file.serial = serial ?? file.serial
+        file.raHash = raHash ?? file.raHash
 
         let existing = file.entries.first {
             $0.code == key && $0.coreIdentifier == coreIdentifier && $0.coreVersion == coreVersion
@@ -156,6 +189,7 @@ final class CheatFeedbackService {
                                                status: status,
                                                notes: existing?.notes,
                                                rawCode: rawCode ?? existing?.rawCode,
+                                               provider: provider ?? existing?.provider,
                                                updatedAt: Date()))
 
         save(file, md5: md5, systemIdentifier: systemIdentifier)
@@ -170,10 +204,18 @@ final class CheatFeedbackService {
                   systemIdentifier: String,
                   coreIdentifier: String,
                   coreVersion: String,
-                  rawCode: String? = nil) {
+                  rawCode: String? = nil,
+                  provider: String? = nil,
+                  gameName: String? = nil,
+                  serial: String? = nil,
+                  raHash: String? = nil) {
         let key = Self.key(for: code)
         var file = load(md5: md5, systemIdentifier: systemIdentifier)
-            ?? CheatFeedbackFile(schemaVersion: Self.schemaVersion, md5: md5, entries: [])
+            ?? CheatFeedbackFile(schemaVersion: Self.schemaVersion, md5: md5, systemIdentifier: systemIdentifier, gameName: gameName, serial: serial, raHash: raHash, entries: [])
+        file.systemIdentifier = systemIdentifier
+        file.gameName = gameName ?? file.gameName
+        file.serial = serial ?? file.serial
+        file.raHash = raHash ?? file.raHash
 
         let existing = file.entries.first {
             $0.code == key && $0.coreIdentifier == coreIdentifier && $0.coreVersion == coreVersion
@@ -194,6 +236,7 @@ final class CheatFeedbackService {
                                                    status: existing?.status,
                                                    notes: newNotes,
                                                    rawCode: rawCode ?? existing?.rawCode,
+                                                   provider: provider ?? existing?.provider,
                                                    updatedAt: Date()))
         }
 
@@ -210,6 +253,10 @@ final class CheatFeedbackService {
             .appendingPathComponent("CheatFeedback", isDirectory: true)
             .appendingPathComponent(systemIdentifier, isDirectory: true)
             .appendingPathComponent("\(md5.uppercased()).json")
+    }
+
+    private func feedbackRootURL() -> URL? {
+        OELibraryDatabase.default?.databaseFolderURL.appendingPathComponent("CheatFeedback", isDirectory: true)
     }
 
     private func load(md5: String, systemIdentifier: String) -> CheatFeedbackFile? {
@@ -239,6 +286,112 @@ final class CheatFeedbackService {
             try encoder.encode(file).write(to: url, options: .atomic)
         } catch {
             // log.error("Failed to write cheat feedback for \(md5): \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Migration
+
+    /// One-time reconciliation for files written before `rawCode`/`provider`/`gameName`/
+    /// `systemIdentifier` existed. Must be called before any game can load, so the still-cached
+    /// provider databases on disk reflect whatever normalization produced the original entries,
+    /// before this session gets a chance to refresh them (e.g. via an ETag-driven re-download).
+    ///
+    /// Synchronous by design: negligible cost at current scale (few users, few systems, few
+    /// feedback files), and it avoids any race with game loading altogether.
+    func migrateIfNeeded() {
+        guard let root = feedbackRootURL() else { return }
+        let configURL = root.appendingPathComponent("config.json")
+
+        var config = loadMigrationConfig(at: configURL) ?? CheatFeedbackMigrationConfig(schemaVersion: 1)
+        guard config.schemaVersion < Self.schemaVersion else { return }
+
+        if let systemDirs = try? fileManager.contentsOfDirectory(at: root, includingPropertiesForKeys: [.isDirectoryKey]) {
+            let libretro = LibretroCheatProvider()
+            let openEmu = OpenEmuCheatProvider()
+
+            for systemDir in systemDirs {
+                guard (try? systemDir.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { continue }
+                let systemIdentifier = systemDir.lastPathComponent
+                guard let files = try? fileManager.contentsOfDirectory(at: systemDir, includingPropertiesForKeys: nil) else { continue }
+                for fileURL in files where fileURL.pathExtension == "json" {
+                    migrateFile(at: fileURL, systemIdentifier: systemIdentifier, libretro: libretro, openEmu: openEmu)
+                }
+            }
+        }
+
+        config.schemaVersion = Self.schemaVersion
+        saveMigrationConfig(config, at: configURL)
+    }
+
+    /// Backfills `rawCode`/`provider` from the still-cached provider databases (matched by
+    /// normalized code), `gameName`/`systemIdentifier`, and `serial` from the ROM library (a second
+    /// fallback identifier alongside MD5, already stored there independent of any game/core running —
+    /// unlike the RetroAchievements hash, which only exists once a core has actually loaded the ROM
+    /// and so can never be recovered during this startup-only migration).
+    /// Entries with no match in either cache (already cleared, or never cached) are left as-is —
+    /// this is best-effort, not a guaranteed reconciliation.
+    private func migrateFile(at fileURL: URL, systemIdentifier: String, libretro: LibretroCheatProvider, openEmu: OpenEmuCheatProvider) {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard var file = try? decoder.decode(CheatFeedbackFile.self, from: data), file.schemaVersion < Self.schemaVersion
+        else { return }
+
+        let openEmuLookup = openEmu.migrationLookup(forMD5: file.md5, systemIdentifier: systemIdentifier)
+        let libretroLookup = libretro.migrationLookup(forMD5: file.md5, systemIdentifier: systemIdentifier)
+
+        var openEmuByCode: [String: String] = [:]
+        for cheat in openEmuLookup?.cheats ?? [] {
+            openEmuByCode[Self.key(for: cheat.code)] = cheat.rawCode
+        }
+        var libretroByCode: [String: String] = [:]
+        for cheat in libretroLookup?.cheats ?? [] {
+            libretroByCode[Self.key(for: cheat.code)] = cheat.rawCode
+        }
+
+        file.systemIdentifier = systemIdentifier
+        // OpenEmu is tried first everywhere else (CheatDatabaseService's provider precedence,
+        // first-match-wins on a duplicate code), so mirror that order here too.
+        file.gameName = file.gameName ?? openEmuLookup?.gameName ?? libretroLookup?.gameName
+        if file.serial == nil, let context = OELibraryDatabase.default?.mainThreadContext {
+            file.serial = (try? OEDBRom.rom(withMD5HashString: file.md5, in: context))?.serial
+        }
+
+        for index in file.entries.indices {
+            let code = file.entries[index].code
+            guard file.entries[index].rawCode == nil || file.entries[index].provider == nil else { continue }
+            if let rawCode = openEmuByCode[code] {
+                file.entries[index].rawCode = file.entries[index].rawCode ?? rawCode
+                file.entries[index].provider = file.entries[index].provider ?? openEmu.name
+            } else if let rawCode = libretroByCode[code] {
+                file.entries[index].rawCode = file.entries[index].rawCode ?? rawCode
+                file.entries[index].provider = file.entries[index].provider ?? libretro.name
+            }
+        }
+
+        file.schemaVersion = Self.schemaVersion
+
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(file).write(to: fileURL, options: .atomic)
+        } catch {
+            // log.error("Failed to write migrated cheat feedback for \(file.md5): \(error.localizedDescription)")
+        }
+    }
+
+    private func loadMigrationConfig(at url: URL) -> CheatFeedbackMigrationConfig? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(CheatFeedbackMigrationConfig.self, from: data)
+    }
+
+    private func saveMigrationConfig(_ config: CheatFeedbackMigrationConfig, at url: URL) {
+        do {
+            try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try JSONEncoder().encode(config).write(to: url, options: .atomic)
+        } catch {
+            // log.error("Failed to write cheat feedback migration config: \(error.localizedDescription)")
         }
     }
 }

--- a/OpenEmu/Cheats.swift
+++ b/OpenEmu/Cheats.swift
@@ -32,18 +32,22 @@ final class Cheat: Codable {
     var name: String
     var isEnabled = false
     var cheatSource: String?
+    /// Unmodified text as published by the provider, before normalization. Not shown to the user;
+    /// carried through for future cheat feedback correlation. `nil` for manual/Cheat Search entries.
+    var rawCode: String?
     /// Set at runtime; not persisted. False when the current core can't handle this code format.
     var isCompatibleWithCore = true
 
     private enum CodingKeys: String, CodingKey {
-        case code, type, name, isEnabled, cheatSource
+        case code, type, name, isEnabled, cheatSource, rawCode
     }
 
-    init(code: String, type: String, name: String, cheatSource: String? = nil) {
+    init(code: String, type: String, name: String, cheatSource: String? = nil, rawCode: String? = nil) {
         self.code = code
         self.type = type
         self.name = name
         self.cheatSource = cheatSource
+        self.rawCode = rawCode
     }
 
     init(from decoder: Decoder) throws {
@@ -53,6 +57,7 @@ final class Cheat: Codable {
         name = try c.decode(String.self, forKey: .name)
         isEnabled = try c.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? false
         cheatSource = try c.decodeIfPresent(String.self, forKey: .cheatSource)
+        rawCode = try c.decodeIfPresent(String.self, forKey: .rawCode)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -62,5 +67,6 @@ final class Cheat: Codable {
         try c.encode(name, forKey: .name)
         try c.encode(isEnabled, forKey: .isEnabled)
         try c.encodeIfPresent(cheatSource, forKey: .cheatSource)
+        try c.encodeIfPresent(rawCode, forKey: .rawCode)
     }
 }

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -89,6 +89,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         OESystemIdentifierPCE:       "NEC - PC Engine - TurboGrafx 16",
         OESystemIdentifierPCECD:     "NEC - PC Engine CD - TurboGrafx-CD",
         OESystemIdentifierSaturn:    "Sega - Saturn",
+        OESystemIdentifierVB:        "Nintendo - Virtual Boy",
     ]
 
     // Systems where a single system ID maps to multiple Libretro DAT/CHT directories
@@ -458,7 +459,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         switch systemIdentifier {
         case OESystemIdentifierSNES, OESystemIdentifierGenesis, OESystemIdentifierSegaCD, OESystemIdentifierPCE, OESystemIdentifierPCECD:
             return 6
-        case OESystemIdentifierGBA:
+        case OESystemIdentifierGBA, OESystemIdentifierVB:
             return 8
         default:
             return 4

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -34,6 +34,12 @@ private let log = Logger(subsystem: "org.openemu.OpenEmu", category: "LibretroCh
 private struct LibretroCachedCheatFile: Codable {
     let sources: [LibretroCachedSource]
     let cheats: [LibretroCachedCheat]
+    /// The DAT/RDB-resolved name, kept separately from `sources` because the winning `.cht`
+    /// filename can be a broader/narrower region variant of it (e.g. RDB says "(Europe)" but
+    /// only a "(USA, Europe)" file exists) — this is the more precise identity for feedback.
+    /// Optional only so cache files written before this field existed still decode; `cheats(forMD5:)`
+    /// force-refreshes any such file once to backfill it.
+    let resolvedGameName: String?
 }
 
 private struct LibretroCachedSource: Codable {
@@ -97,6 +103,24 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
     // Guards datCache; cheats(forMD5:) runs off the caller's actor, so multiple windows can hit it at once.
     private let datCacheLock = NSLock()
 
+    // Games whose whole cheat catalogue has already been rediscovered from scratch this app
+    // session — reset naturally on relaunch, since this is in-memory only. Keeps repeated visits
+    // to the same game within a session from re-running the full candidate search every time.
+    private var sessionRediscoveredGames: Set<String> = []
+    private let sessionRediscoveredGamesLock = NSLock()
+
+    /// Returns true (and marks the game) only the first time it's called for this md5/system in
+    /// the current session. Marks eagerly, before the rediscovery attempt itself, so a failed
+    /// attempt (e.g. offline) isn't retried on every subsequent call in the same session.
+    private func beginSessionRediscoveryIfNeeded(md5: String, systemIdentifier: String) -> Bool {
+        let key = "\(systemIdentifier)/\(md5.uppercased())"
+        sessionRediscoveredGamesLock.lock()
+        defer { sessionRediscoveredGamesLock.unlock() }
+        guard !sessionRediscoveredGames.contains(key) else { return false }
+        sessionRediscoveredGames.insert(key)
+        return true
+    }
+
     func supportsSystem(_ systemIdentifier: String) -> Bool {
         systemMap[systemIdentifier] != nil
     }
@@ -107,6 +131,18 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         // 1. Check local cache
         if let cached = loadCachedCheats(md5: md5, systemIdentifier: systemIdentifier) {
             log.info("Local cache hit for \(md5) (\(cached.sources.map(\.chtFileName).joined(separator: ", ")))")
+
+            // Once per app session, rebuild this game's whole catalogue from scratch — cheats can be
+            // renamed, added, or removed upstream, and the ETag refresh below only ever re-validates
+            // filenames it already knows about, so it can never discover or react to either. Any
+            // failure here (offline, or genuinely nothing found) falls back to the existing cache
+            // untouched, so offline play is never affected by a failed background refresh.
+            if beginSessionRediscoveryIfNeeded(md5: md5, systemIdentifier: systemIdentifier),
+               let discovered = try? await discoverCheats(md5: md5, serial: serial, gameName: gameName, romURL: romURL, systemIdentifier: systemIdentifier, libretroSystem: libretroSystem) {
+                saveCachedCheats(LibretroCachedCheatFile(sources: discovered.sources, cheats: discovered.cheats, resolvedGameName: discovered.resolvedGameName), md5: md5, systemIdentifier: systemIdentifier)
+                return discovered.cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode ?? $0.code) }
+            }
+
             // Try to update each cached source
             var anyUpdated = false
             var allCheats: [LibretroCachedCheat] = []
@@ -127,55 +163,53 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
             }
             let cheats = anyUpdated ? dedup(allCheats) : cached.cheats
             if anyUpdated {
-                saveCachedCheats(LibretroCachedCheatFile(sources: updatedSources, cheats: cheats), md5: md5, systemIdentifier: systemIdentifier)
+                saveCachedCheats(LibretroCachedCheatFile(sources: updatedSources, cheats: cheats, resolvedGameName: cached.resolvedGameName), md5: md5, systemIdentifier: systemIdentifier)
             }
             return cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode ?? $0.code) }
         }
 
-        // 2. No local cache — resolve game name via DAT (try MD5 first, then serial)
-        // For disc systems, OpenEmu's stored MD5 hashes the .cue playlist file, not the disc data,
-        // so it never matches Libretro's per-track MD5s. Recompute the data track's MD5 when possible.
-        var lookupMD5 = md5
-        var lookup: (name: String, libretroSystem: String)?
-        if Self.redumpSystems.contains(systemIdentifier), let romURL {
-            // Some discs (esp. PC Engine CD, occasionally Saturn) don't keep their identifying
-            // data on the first track — try every non-audio track's MD5 in cue order until one matches.
-            for candidate in dataTrackMD5Candidates(forCueURL: romURL) {
-                if let result = try await lookupGameName(md5: candidate, serial: nil, systemIdentifier: systemIdentifier) {
-                    lookupMD5 = candidate
-                    lookup = result
-                    break
-                }
-            }
+        // 2. No local cache — full discovery from scratch
+        guard let discovered = try await discoverCheats(md5: md5, serial: serial, gameName: gameName, romURL: romURL, systemIdentifier: systemIdentifier, libretroSystem: libretroSystem) else {
+            return []
         }
-        // Lynx .lnx dumps prepend a 64-byte header; the no-intro DAT indexes the headerless image.
-        if lookup == nil, systemIdentifier == OESystemIdentifierLynx, let romURL,
-           let recomputed = headerlessLynxMD5(forROMURL: romURL) {
-            lookupMD5 = recomputed
-        }
+        _ = beginSessionRediscoveryIfNeeded(md5: md5, systemIdentifier: systemIdentifier)
+        saveCachedCheats(LibretroCachedCheatFile(sources: discovered.sources, cheats: discovered.cheats, resolvedGameName: discovered.resolvedGameName), md5: md5, systemIdentifier: systemIdentifier)
+        return discovered.cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode ?? $0.code) }
+    }
 
-        if lookup == nil {
-            lookup = try await lookupGameName(md5: lookupMD5, serial: serial, systemIdentifier: systemIdentifier)
-        }
+    private struct DiscoveredCheats {
+        let sources: [LibretroCachedSource]
+        let cheats: [LibretroCachedCheat]
+        let resolvedGameName: String?
+    }
+
+    /// Runs the full candidate search from scratch (DAT lookup, then name/suffix/region variants),
+    /// ignoring any existing local cache entirely. Returns nil if nothing matched upstream, so the
+    /// caller can decide how to fall back — this never touches the disk cache itself.
+    private func discoverCheats(md5: String, serial: String?, gameName: String?, romURL: URL?, systemIdentifier: String, libretroSystem: String) async throws -> DiscoveredCheats? {
+        // Resolve game name via DAT (try MD5 first, then serial). For disc systems, OpenEmu's stored
+        // MD5 hashes the .cue playlist file, not the disc data, so it never matches Libretro's
+        // per-track MD5s — resolveDATName recomputes the data track's MD5 when possible.
+        let lookup = try await resolveDATName(md5: md5, serial: serial, romURL: romURL, systemIdentifier: systemIdentifier)
 
         if lookup == nil && gameName == nil {
             log.info("No game found for MD5 \(md5) / serial \(serial ?? "nil") in system \(systemIdentifier)")
-            return []
+            return nil
         }
 
         let resolvedSystem = lookup?.libretroSystem ?? libretroSystem
         log.info("MD5 \(md5) → \(lookup?.name ?? "nil") (in \(resolvedSystem))")
 
-        // 3. Download plain + device-suffixed + region-variant candidates, merge
+        // Download plain + device-suffixed + region-variant candidates, merge
         var allCheats: [LibretroCachedCheat] = []
         var sources: [LibretroCachedSource] = []
 
         let useRegionFallback = systemIdentifier == OESystemIdentifierPSX || systemIdentifier == OESystemIdentifierSaturn
         var gameNames: [String] = []
-        if let name = lookup?.name {
-            gameNames.append(name)
-            gameNames += compoundRegionVariants(for: name)
-            if useRegionFallback { gameNames += regionVariants(for: name) }
+        if let lookupName = lookup?.name {
+            gameNames.append(lookupName)
+            gameNames += compoundRegionVariants(for: lookupName)
+            if useRegionFallback { gameNames += regionVariants(for: lookupName) }
         }
 
         // Fallback: try the library game name if the DAT lookup didn't work or wasn't found.
@@ -187,8 +221,8 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
             if useRegionFallback { gameNames += regionVariants(for: gameName) }
         }
 
-        for gameName in gameNames {
-            let candidates = ["\(gameName).cht"] + Self.chtSuffixes.map { "\(gameName) (\($0)).cht" }
+        for candidateName in gameNames {
+            let candidates = ["\(candidateName).cht"] + Self.chtSuffixes.map { "\(candidateName) (\($0)).cht" }
             for candidate in candidates {
                 if let result = try await downloadCHT(chtFileName: candidate, libretroSystem: resolvedSystem, systemIdentifier: systemIdentifier, existingETag: nil) {
                     allCheats.append(contentsOf: result.cheats)
@@ -200,12 +234,10 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
 
         guard !allCheats.isEmpty else {
             log.info("No CHT files found for \(gameNames.joined(separator: ", "))")
-            return []
+            return nil
         }
 
-        let cheats = dedup(allCheats)
-        saveCachedCheats(LibretroCachedCheatFile(sources: sources, cheats: cheats), md5: md5, systemIdentifier: systemIdentifier)
-        return cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode ?? $0.code) }
+        return DiscoveredCheats(sources: sources, cheats: dedup(allCheats), resolvedGameName: lookup?.name)
     }
 
     // MARK: - Local Cache
@@ -262,7 +294,9 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
     /// Returns nil if this game has no cache yet (nothing to reconcile against).
     func migrationLookup(forMD5 md5: String, systemIdentifier: String) -> (gameName: String?, cheats: [(code: String, rawCode: String)])? {
         guard let cached = loadCachedCheats(md5: md5, systemIdentifier: systemIdentifier) else { return nil }
-        let gameName = cached.sources.first.map { Self.gameName(fromCHTFileName: $0.chtFileName) }
+        // Prefer the DAT-resolved name (more precise) over the winning .cht filename, which can be
+        // a broader/narrower region variant when the exact resolved name had no matching file.
+        let gameName = cached.resolvedGameName ?? cached.sources.first.map { Self.gameName(fromCHTFileName: $0.chtFileName) }
         return (gameName, cached.cheats.map { ($0.code, $0.rawCode ?? $0.code) })
     }
 
@@ -792,6 +826,29 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
             if let result = cache[key] { return result }
         }
         return nil
+    }
+
+    /// Resolves the DAT/RDB name for a ROM, trying (in order): redump per-track MD5 candidates for
+    /// disc systems, a headerless MD5 for Lynx, then the plain MD5 (falling back to serial). Shared
+    /// by the no-cache fetch path and the cache-hit gameName backfill, so both resolve identically.
+    private func resolveDATName(md5: String, serial: String?, romURL: URL?, systemIdentifier: String) async throws -> (name: String, libretroSystem: String)? {
+        if Self.redumpSystems.contains(systemIdentifier), let romURL {
+            // Some discs (esp. PC Engine CD, occasionally Saturn) don't keep their identifying
+            // data on the first track — try every non-audio track's MD5 in cue order until one matches.
+            for candidate in dataTrackMD5Candidates(forCueURL: romURL) {
+                if let result = try await lookupGameName(md5: candidate, serial: nil, systemIdentifier: systemIdentifier) {
+                    return result
+                }
+            }
+        }
+
+        var lookupMD5 = md5
+        // Lynx .lnx dumps prepend a 64-byte header; the no-intro DAT indexes the headerless image.
+        if systemIdentifier == OESystemIdentifierLynx, let romURL,
+           let recomputed = headerlessLynxMD5(forROMURL: romURL) {
+            lookupMD5 = recomputed
+        }
+        return try await lookupGameName(md5: lookupMD5, serial: serial, systemIdentifier: systemIdentifier)
     }
 
     private func lookupGameName(md5: String, serial: String?, systemIdentifier: String) async throws -> (name: String, libretroSystem: String)? {

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -28,7 +28,7 @@ import OpenEmuBase
 import CryptoKit
 import os.log
 
-// private let log = Logger(subsystem: "org.openemu.OpenEmu", category: "LibretroCheatProvider")
+private let log = Logger(subsystem: "org.openemu.OpenEmu", category: "LibretroCheatProvider")
 
 /// Cached cheat file stored on disk per game.
 private struct LibretroCachedCheatFile: Codable {
@@ -101,7 +101,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
 
         // 1. Check local cache
         if let cached = loadCachedCheats(md5: md5, systemIdentifier: systemIdentifier) {
-            // log.info("Local cache hit for \(md5) (\(cached.sources.map(\.chtFileName).joined(separator: ", ")))")
+            log.info("Local cache hit for \(md5) (\(cached.sources.map(\.chtFileName).joined(separator: ", ")))")
             // Try to update each cached source
             var anyUpdated = false
             var allCheats: [LibretroCachedCheat] = []
@@ -154,12 +154,12 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         }
 
         if lookup == nil && gameName == nil {
-            // log.info("No game found for MD5 \(md5) / serial \(serial ?? "nil") in system \(systemIdentifier)")
+            log.info("No game found for MD5 \(md5) / serial \(serial ?? "nil") in system \(systemIdentifier)")
             return []
         }
 
         let resolvedSystem = lookup?.libretroSystem ?? libretroSystem
-        // log.info("MD5 \(md5) → \(lookup?.name ?? "nil") (in \(resolvedSystem))")
+        log.info("MD5 \(md5) → \(lookup?.name ?? "nil") (in \(resolvedSystem))")
 
         // 3. Download plain + device-suffixed + region-variant candidates, merge
         var allCheats: [LibretroCachedCheat] = []
@@ -194,7 +194,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         }
 
         guard !allCheats.isEmpty else {
-            // log.info("No CHT files found for \(gameNames.joined(separator: ", "))")
+            log.info("No CHT files found for \(gameNames.joined(separator: ", "))")
             return []
         }
 
@@ -308,7 +308,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
 
         let newETag = httpResponse.value(forHTTPHeaderField: "ETag")?.replacingOccurrences(of: "\"", with: "")
         let cheats = parseCHTFile(data, systemIdentifier: systemIdentifier)
-        // log.info("CHT parsed: \(chtFileName) → \(cheats.count) cheats")
+        log.info("CHT parsed: \(chtFileName) → \(cheats.count) cheats")
         return CHTDownloadResult(cheats: cheats, etag: newETag)
     }
 
@@ -738,7 +738,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         let cachedSnapshot = datCache[systemIdentifier]
         datCacheLock.unlock()
         if let cached = cachedSnapshot {
-            // log.debug("DAT cache hit for \(systemIdentifier)")
+            log.debug("DAT cache hit for \(systemIdentifier)")
             if let result = cached[md5.uppercased()] { return result }
             if let serial, let result = lookupBySerial(serial, in: cached) { return result }
             return nil
@@ -749,7 +749,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         let datSystems = systemFallbacks[systemIdentifier] ?? [libretroSystem]
         var merged: [String: (name: String, libretroSystem: String)] = [:]
         for datSystem in datSystems {
-            // log.info("Downloading DAT for \(datSystem)…")
+            log.info("Downloading DAT for \(datSystem)…")
             let encoded = datSystem.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? datSystem
             let datBaseURL = Self.redumpSystems.contains(systemIdentifier) ? Self.datBaseURLRedump : Self.datBaseURLNoIntro
             guard let url = URL(string: "\(datBaseURL)\(encoded).dat") else { continue }

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -59,7 +59,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
     private static let chtBaseURL = "https://raw.githubusercontent.com/libretro/libretro-database/master/cht/"
 
     // Disc-based systems use redump DATs instead of no-intro
-    private static let redumpSystems: Set<String> = [OESystemIdentifierPSX, OESystemIdentifierSegaCD, OESystemIdentifierPCECD]
+    private static let redumpSystems: Set<String> = [OESystemIdentifierPSX, OESystemIdentifierSegaCD, OESystemIdentifierPCECD, OESystemIdentifierSaturn]
 
     // OpenEmu system ID → Libretro directory/DAT name
     private let systemMap: [String: String] = [
@@ -82,6 +82,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         OESystemIdentifierNGP:       "SNK - Neo Geo Pocket",
         OESystemIdentifierPCE:       "NEC - PC Engine - TurboGrafx 16",
         OESystemIdentifierPCECD:     "NEC - PC Engine CD - TurboGrafx-CD",
+        OESystemIdentifierSaturn:    "Sega - Saturn",
     ]
 
     // Systems where a single system ID maps to multiple Libretro DAT/CHT directories
@@ -169,7 +170,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         var allCheats: [LibretroCachedCheat] = []
         var sources: [LibretroCachedSource] = []
 
-        let useRegionFallback = systemIdentifier == OESystemIdentifierPSX
+        let useRegionFallback = systemIdentifier == OESystemIdentifierPSX || systemIdentifier == OESystemIdentifierSaturn
         var gameNames: [String] = []
         if let name = lookup?.name {
             gameNames.append(name)
@@ -404,6 +405,12 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
             var cleaned = code.replacingOccurrences(of: " ", with: "")
                               .replacingOccurrences(of: ";", with: "+")
             cleaned = normalizeCode(cleaned, systemIdentifier: systemIdentifier)
+            // Saturn: reject anything that isn't a plain word/byte write (also catches Master Codes
+            // and the RetroArch/Format-B entries this system doesn't support yet).
+            if systemIdentifier == OESystemIdentifierSaturn,
+               !cleaned.split(separator: "+").allSatisfy({ CheatCodeValidator.isSaturnActionReplayCode(String($0)) }) {
+                continue
+            }
             guard !seenCodes.contains(cleaned) else { continue }
             seenCodes.insert(cleaned)
             cheats.append(LibretroCachedCheat(name: Self.decodingHTMLEntities(desc), code: cleaned, rawCode: rawCode))
@@ -466,6 +473,8 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
             return normalizeGameGearCode(code)
         case OESystemIdentifierPSX:
             return normalizePSXCode(code)
+        case OESystemIdentifierSaturn:
+            return normalizeSaturnCode(code)
         default:
             return code
         }
@@ -517,6 +526,30 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
             else {
                 return code
             }
+        }
+        return codes.joined(separator: "+")
+    }
+
+    /// Saturn GameShark/Action Replay: 8-hex address (type nibble + 24-bit address) + '+' + 4-hex
+    /// value, chained with '+' for multi-part patches. Concatenates each pair into a contiguous
+    /// 12-hex code, matching the native `TAAAAAAA` + `VVVV` shape `MednafenGameCore`'s `ss` branch
+    /// expects (its own space is stripped before parsing there).
+    private func normalizeSaturnCode(_ code: String) -> String {
+        let parts = code.split(separator: "+").map { String($0) }
+        guard parts.count >= 2, parts.count.isMultiple(of: 2) else { return code }
+
+        var codes: [String] = []
+        var i = 0
+        while i < parts.count {
+            var addr = parts[i]
+            let val = parts[i + 1]
+            // Some entries drop the address's leading zero (e.g. "160CE42" for "0160CE42").
+            if addr.count == 7, addr.allSatisfy(\.isHexDigit) { addr = "0" + addr }
+            guard addr.count == 8, addr.allSatisfy(\.isHexDigit), val.count == 4, val.allSatisfy(\.isHexDigit) else {
+                return code
+            }
+            codes.append("\(addr)\(val)")
+            i += 2
         }
         return codes.joined(separator: "+")
     }

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -74,6 +74,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         OESystemIdentifierGB:        "Nintendo - Game Boy",
         OESystemIdentifierColecoVision: "Coleco - ColecoVision",
         OESystemIdentifierPSX:       "Sony - PlayStation",
+        OESystemIdentifierLynx:      "Atari - Lynx",
     ]
 
     // Systems where a single system ID maps to multiple Libretro DAT/CHT directories
@@ -128,6 +129,11 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         var lookupMD5 = md5
         if Self.redumpSystems.contains(systemIdentifier), let romURL,
            let recomputed = dataTrackMD5(forCueURL: romURL) {
+            lookupMD5 = recomputed
+        }
+        // Lynx .lnx dumps prepend a 64-byte header; the no-intro DAT indexes the headerless image.
+        if systemIdentifier == OESystemIdentifierLynx, let romURL,
+           let recomputed = headerlessLynxMD5(forROMURL: romURL) {
             lookupMD5 = recomputed
         }
 
@@ -620,6 +626,25 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
                 remaining = r - data.count
                 if remaining! <= 0 { break }
             }
+        }
+
+        return md5.finalize().map { String(format: "%02X", $0) }.joined()
+    }
+
+    /// Atari Lynx `.lnx` dumps prepend a 64-byte header ("LYNX" magic); the no-intro DAT
+    /// indexes the headerless image, so recompute the MD5 over the data past the header.
+    /// Returns nil when the file has no header (its MD5 already matches the DAT).
+    private func headerlessLynxMD5(forROMURL romURL: URL) -> String? {
+        guard let file = try? FileHandle(forReadingFrom: romURL) else { return nil }
+        defer { try? file.close() }
+
+        guard let magic = try? file.read(upToCount: 4), magic == Data("LYNX".utf8) else { return nil }
+        do { try file.seek(toOffset: 64) } catch { return nil }
+
+        var md5 = Insecure.MD5()
+        let bufferSize = 1024 * 1024
+        while let data = try? file.read(upToCount: bufferSize), !data.isEmpty {
+            md5.update(data: data)
         }
 
         return md5.finalize().map { String(format: "%02X", $0) }.joined()

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -134,7 +134,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
 
         // 1. Check local cache
         if let cached = loadCachedCheats(md5: md5, systemIdentifier: systemIdentifier) {
-            log.info("Local cache hit for \(md5) (\(cached.sources.map(\.chtFileName).joined(separator: ", ")))")
+            // log.info("Local cache hit for \(md5) (\(cached.sources.map(\.chtFileName).joined(separator: ", ")))")
 
             // Once per app session, rebuild this game's whole catalogue from scratch — cheats can be
             // renamed, added, or removed upstream, and the ETag refresh below only ever re-validates
@@ -197,12 +197,12 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         let lookup = try await resolveDATName(md5: md5, serial: serial, romURL: romURL, systemIdentifier: systemIdentifier)
 
         if lookup == nil && gameName == nil {
-            log.info("No game found for MD5 \(md5) / serial \(serial ?? "nil") in system \(systemIdentifier)")
+            // log.info("No game found for MD5 \(md5) / serial \(serial ?? "nil") in system \(systemIdentifier)")
             return nil
         }
 
         let resolvedSystem = lookup?.libretroSystem ?? libretroSystem
-        log.info("MD5 \(md5) → \(lookup?.name ?? "nil") (in \(resolvedSystem))")
+        // log.info("MD5 \(md5) → \(lookup?.name ?? "nil") (in \(resolvedSystem))")
 
         // Download plain + device-suffixed + region-variant candidates, merge
         var allCheats: [LibretroCachedCheat] = []
@@ -237,7 +237,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         }
 
         guard !allCheats.isEmpty else {
-            log.info("No CHT files found for \(gameNames.joined(separator: ", "))")
+            // log.info("No CHT files found for \(gameNames.joined(separator: ", "))")
             return nil
         }
 
@@ -374,7 +374,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
 
         let newETag = httpResponse.value(forHTTPHeaderField: "ETag")?.replacingOccurrences(of: "\"", with: "")
         let cheats = parseCHTFile(data, systemIdentifier: systemIdentifier)
-        log.info("CHT parsed: \(chtFileName) → \(cheats.count) cheats")
+        // log.info("CHT parsed: \(chtFileName) → \(cheats.count) cheats")
         return CHTDownloadResult(cheats: cheats, etag: newETag)
     }
 
@@ -860,7 +860,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         let cachedSnapshot = datCache[systemIdentifier]
         datCacheLock.unlock()
         if let cached = cachedSnapshot {
-            log.debug("DAT cache hit for \(systemIdentifier)")
+            // log.debug("DAT cache hit for \(systemIdentifier)")
             if let result = cached[md5.uppercased()] { return result }
             if let serial, let result = lookupBySerial(serial, in: cached) { return result }
             return nil
@@ -871,7 +871,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         let datSystems = systemFallbacks[systemIdentifier] ?? [libretroSystem]
         var merged: [String: (name: String, libretroSystem: String)] = [:]
         for datSystem in datSystems {
-            log.info("Downloading DAT for \(datSystem)…")
+            // log.info("Downloading DAT for \(datSystem)…")
             let encoded = datSystem.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? datSystem
             let datBaseURL = Self.redumpSystems.contains(systemIdentifier) ? Self.datBaseURLRedump : Self.datBaseURLNoIntro
             guard let url = URL(string: "\(datBaseURL)\(encoded).dat") else { continue }

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -76,6 +76,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         OESystemIdentifierPSX:       "Sony - PlayStation",
         OESystemIdentifierLynx:      "Atari - Lynx",
         OESystemIdentifierNGP:       "SNK - Neo Geo Pocket",
+        OESystemIdentifierPCE:       "NEC - PC Engine - TurboGrafx 16",
     ]
 
     // Systems where a single system ID maps to multiple Libretro DAT/CHT directories
@@ -347,8 +348,12 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
 
             // If code is empty, try to synthesize from address + value (Format B)
             // TODO: handle big_endian and memory_search_size for multi-byte systems
-            // TODO: filter by cheat_type — only type 1 (set to value) is usable; types 2-7 need RetroArch's RAM engine
-            if code.isEmpty, let addrStr = fields["address"], let valStr = fields["value"],
+            // Only cheat_type "1" (Set To Value) is a plain memory patch we can express as ADDRESS:VALUE.
+            // Other types (e.g. "0", used by rumble-on-match entries with populated rumble_* fields) are
+            // conditional/behavioral cheats RetroArch's RAM engine handles specially, not simple patches.
+            let cheatType = fields["cheat_type"]
+            let isPlainSetToValue = cheatType == nil || cheatType == "1"
+            if code.isEmpty, isPlainSetToValue, let addrStr = fields["address"], let valStr = fields["value"],
                let addr = UInt32(addrStr), let val = UInt32(valStr) {
                 // Pad the address to the width the per-system raw ADDRESS:VALUE validator expects.
                 let addressHexChars = Self.formatBAddressHexChars(for: systemIdentifier)

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -75,11 +75,13 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         OESystemIdentifierColecoVision: "Coleco - ColecoVision",
         OESystemIdentifierPSX:       "Sony - PlayStation",
         OESystemIdentifierLynx:      "Atari - Lynx",
+        OESystemIdentifierNGP:       "SNK - Neo Geo Pocket",
     ]
 
     // Systems where a single system ID maps to multiple Libretro DAT/CHT directories
     private let systemFallbacks: [String: [String]] = [
         OESystemIdentifierGB: ["Nintendo - Game Boy", "Nintendo - Game Boy Color"],
+        OESystemIdentifierNGP: ["SNK - Neo Geo Pocket", "SNK - Neo Geo Pocket Color"],
     ]
 
     // In-memory cache: systemIdentifier → [key → (gameName, libretroSystem)]

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -44,6 +44,8 @@ private struct LibretroCachedSource: Codable {
 private struct LibretroCachedCheat: Codable {
     let name: String
     let code: String
+    /// Unmodified text as published upstream, kept for feedback correlation. Never shown to the user.
+    let rawCode: String
 }
 
 final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
@@ -113,7 +115,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
                     anyUpdated = true
                 } else if !anyUpdated {
                     // Nothing updated yet — return the full cached set as-is
-                    return cached.cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name) }
+                    return cached.cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode) }
                 } else {
                     // Some sources updated, this one didn't — keep cached cheats and this source's existing ETag
                     allCheats.append(contentsOf: cached.cheats)
@@ -124,7 +126,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
             if anyUpdated {
                 saveCachedCheats(LibretroCachedCheatFile(sources: updatedSources, cheats: cheats), md5: md5, systemIdentifier: systemIdentifier)
             }
-            return cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name) }
+            return cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode) }
         }
 
         // 2. No local cache — resolve game name via DAT (try MD5 first, then serial)
@@ -200,7 +202,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
 
         let cheats = dedup(allCheats)
         saveCachedCheats(LibretroCachedCheatFile(sources: sources, cheats: cheats), md5: md5, systemIdentifier: systemIdentifier)
-        return cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name) }
+        return cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode) }
     }
 
     // MARK: - Local Cache
@@ -372,13 +374,14 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
             }
 
             guard !code.isEmpty else { continue }
+            let rawCode = code
             // Normalize separators: some CHT files use ';' instead of '+'
             var cleaned = code.replacingOccurrences(of: " ", with: "")
                               .replacingOccurrences(of: ";", with: "+")
             cleaned = normalizeCode(cleaned, systemIdentifier: systemIdentifier)
             guard !seenCodes.contains(cleaned) else { continue }
             seenCodes.insert(cleaned)
-            cheats.append(LibretroCachedCheat(name: Self.decodingHTMLEntities(desc), code: cleaned))
+            cheats.append(LibretroCachedCheat(name: Self.decodingHTMLEntities(desc), code: cleaned, rawCode: rawCode))
         }
 
         return cheats

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -55,7 +55,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
     private static let chtBaseURL = "https://raw.githubusercontent.com/libretro/libretro-database/master/cht/"
 
     // Disc-based systems use redump DATs instead of no-intro
-    private static let redumpSystems: Set<String> = [OESystemIdentifierPSX, OESystemIdentifierSegaCD]
+    private static let redumpSystems: Set<String> = [OESystemIdentifierPSX, OESystemIdentifierSegaCD, OESystemIdentifierPCECD]
 
     // OpenEmu system ID → Libretro directory/DAT name
     private let systemMap: [String: String] = [
@@ -77,6 +77,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         OESystemIdentifierLynx:      "Atari - Lynx",
         OESystemIdentifierNGP:       "SNK - Neo Geo Pocket",
         OESystemIdentifierPCE:       "NEC - PC Engine - TurboGrafx 16",
+        OESystemIdentifierPCECD:     "NEC - PC Engine CD - TurboGrafx-CD",
     ]
 
     // Systems where a single system ID maps to multiple Libretro DAT/CHT directories
@@ -130,17 +131,27 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         // For disc systems, OpenEmu's stored MD5 hashes the .cue playlist file, not the disc data,
         // so it never matches Libretro's per-track MD5s. Recompute the data track's MD5 when possible.
         var lookupMD5 = md5
-        if Self.redumpSystems.contains(systemIdentifier), let romURL,
-           let recomputed = dataTrackMD5(forCueURL: romURL) {
-            lookupMD5 = recomputed
+        var lookup: (name: String, libretroSystem: String)?
+        if Self.redumpSystems.contains(systemIdentifier), let romURL {
+            // Some discs (esp. PC Engine CD, occasionally Saturn) don't keep their identifying
+            // data on the first track — try every non-audio track's MD5 in cue order until one matches.
+            for candidate in dataTrackMD5Candidates(forCueURL: romURL) {
+                if let result = try await lookupGameName(md5: candidate, serial: nil, systemIdentifier: systemIdentifier) {
+                    lookupMD5 = candidate
+                    lookup = result
+                    break
+                }
+            }
         }
         // Lynx .lnx dumps prepend a 64-byte header; the no-intro DAT indexes the headerless image.
-        if systemIdentifier == OESystemIdentifierLynx, let romURL,
+        if lookup == nil, systemIdentifier == OESystemIdentifierLynx, let romURL,
            let recomputed = headerlessLynxMD5(forROMURL: romURL) {
             lookupMD5 = recomputed
         }
 
-        let lookup = try await lookupGameName(md5: lookupMD5, serial: serial, systemIdentifier: systemIdentifier)
+        if lookup == nil {
+            lookup = try await lookupGameName(md5: lookupMD5, serial: serial, systemIdentifier: systemIdentifier)
+        }
 
         if lookup == nil && gameName == nil {
             // log.info("No game found for MD5 \(md5) / serial \(serial ?? "nil") in system \(systemIdentifier)")
@@ -376,7 +387,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
     /// Address hex-digit width the raw ADDRESS:VALUE validator expects per system (see CheatCodeValidator).
     private static func formatBAddressHexChars(for systemIdentifier: String) -> Int {
         switch systemIdentifier {
-        case OESystemIdentifierSNES, OESystemIdentifierGenesis, OESystemIdentifierSegaCD:
+        case OESystemIdentifierSNES, OESystemIdentifierGenesis, OESystemIdentifierSegaCD, OESystemIdentifierPCE, OESystemIdentifierPCECD:
             return 6
         case OESystemIdentifierGBA:
             return 8
@@ -549,28 +560,34 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
 
     // MARK: - Data Track MD5 Recomputation
 
-    /// Describes where the disc's data track lives and how many bytes of it to hash.
-    /// `length == nil` means "hash the whole referenced file" (single-track disc, or the
-    /// data track already lives in its own separate file per the CUE's FILE statements).
+    /// Describes one candidate data track: where it lives and how many bytes of it to hash.
+    /// `length == nil` means "hash to EOF" (last/only track in its file).
     private struct CUEDataTrackLayout {
         let fileURL: URL
+        let offset: Int
         let length: Int?
     }
 
-    /// Parses a CUE sheet to find the data track (always the first track) and, if a second
-    /// track shares the same underlying file (as with a merged chdman `extractcd` dump),
-    /// the byte offset where that second track begins.
-    private func parseCUEDataTrackLayout(cueURL: URL) -> CUEDataTrackLayout? {
-        guard let content = try? String(contentsOf: cueURL, encoding: .utf8) else { return nil }
+    /// Parses a CUE sheet into every non-audio (MODEx) track's byte range, in cue order.
+    /// PSX/Sega CD always keep their data on the first track, but PC Engine CD (and occasionally
+    /// Saturn) sometimes put it on a later track — callers try each returned candidate in order.
+    /// Handles both "one file per track" dumps (the common case; each data track hashes whole-file)
+    /// and merged single-bin dumps (as with a chdman `extractcd` dump), where a track's end is
+    /// bounded by the next track sharing the same FILE section.
+    private func parseCUEDataTrackLayouts(cueURL: URL) -> [CUEDataTrackLayout] {
+        guard let content = try? String(contentsOf: cueURL, encoding: .utf8) else { return [] }
         let folderURL = cueURL.deletingLastPathComponent()
 
-        struct TrackEntry { var indices: [Int: (mm: Int, ss: Int, ff: Int)] = [:] }
+        struct TrackEntry {
+            var mode: String = ""
+            var indices: [Int: (mm: Int, ss: Int, ff: Int)] = [:]
+        }
         struct FileSection { let fileName: String; var tracks: [TrackEntry] = [] }
 
         var sections: [FileSection] = []
 
         let filePattern = try! NSRegularExpression(pattern: #"^FILE\s+"([^"]+)""#)
-        let trackPattern = try! NSRegularExpression(pattern: #"^TRACK\s+\d+"#)
+        let trackPattern = try! NSRegularExpression(pattern: #"^TRACK\s+\d+\s+(\S+)"#)
         let indexPattern = try! NSRegularExpression(pattern: #"^INDEX\s+(\d+)\s+(\d+):(\d+):(\d+)"#)
 
         for rawLine in content.components(separatedBy: .newlines) {
@@ -580,9 +597,12 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
             if let match = filePattern.firstMatch(in: line, range: fullRange),
                let nameRange = Range(match.range(at: 1), in: line) {
                 sections.append(FileSection(fileName: String(line[nameRange])))
-            } else if trackPattern.firstMatch(in: line, range: fullRange) != nil {
+            } else if let match = trackPattern.firstMatch(in: line, range: fullRange),
+                      let modeRange = Range(match.range(at: 1), in: line) {
                 guard !sections.isEmpty else { continue }
-                sections[sections.count - 1].tracks.append(TrackEntry())
+                var entry = TrackEntry()
+                entry.mode = String(line[modeRange]).uppercased()
+                sections[sections.count - 1].tracks.append(entry)
             } else if let match = indexPattern.firstMatch(in: line, range: fullRange),
                       let idxRange = Range(match.range(at: 1), in: line),
                       let mmRange = Range(match.range(at: 2), in: line),
@@ -595,47 +615,62 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
             }
         }
 
-        guard let firstSection = sections.first, !firstSection.tracks.isEmpty else { return nil }
-        let dataTrackURL = folderURL.appendingPathComponent(firstSection.fileName)
-
-        // A second track in the SAME file section marks where the data track ends (merged dump)
-        if firstSection.tracks.count > 1 {
-            let secondTrack = firstSection.tracks[1]
-            if let msf = secondTrack.indices[0] ?? secondTrack.indices[1] {
-                let sectors = (msf.mm * 60 + msf.ss) * 75 + msf.ff
-                return CUEDataTrackLayout(fileURL: dataTrackURL, length: sectors * 2352)
-            }
+        func bytes(_ msf: (mm: Int, ss: Int, ff: Int)) -> Int {
+            ((msf.mm * 60 + msf.ss) * 75 + msf.ff) * 2352
         }
 
-        // Single track, or the next track lives in its own separate file — hash the whole file
-        return CUEDataTrackLayout(fileURL: dataTrackURL, length: nil)
+        var layouts: [CUEDataTrackLayout] = []
+        for section in sections {
+            let fileURL = folderURL.appendingPathComponent(section.fileName)
+            for (i, track) in section.tracks.enumerated() {
+                guard track.mode.hasPrefix("MODE") else { continue }
+
+                // Prefer INDEX 00 (this track's own pregap, folded into the track before the
+                // next track's index) for where it starts — matches how Redump/Libretro hash tracks.
+                let start = (track.indices[0] ?? track.indices[1]).map(bytes) ?? 0
+
+                // Prefer the next track's INDEX 00 for where this one ends, same convention.
+                var length: Int?
+                if i + 1 < section.tracks.count,
+                   let nextMSF = section.tracks[i + 1].indices[0] ?? section.tracks[i + 1].indices[1] {
+                    length = bytes(nextMSF) - start
+                }
+
+                layouts.append(CUEDataTrackLayout(fileURL: fileURL, offset: start, length: length))
+            }
+        }
+        return layouts
     }
 
-    /// Recomputes the MD5 of just the disc's data track, matching how Libretro/Redump hash CD images.
+    /// Recomputes the MD5 of each candidate data track, matching how Libretro/Redump hash CD images.
     /// OpenEmu's stored MD5 for CUE-based imports hashes the playlist text file, not disc content,
     /// so it can never match the DAT — this recomputes it directly from the referenced binary.
-    private func dataTrackMD5(forCueURL cueURL: URL) -> String? {
-        guard cueURL.pathExtension.lowercased() == "cue" else { return nil }
-        guard let layout = parseCUEDataTrackLayout(cueURL: cueURL) else { return nil }
+    private func dataTrackMD5Candidates(forCueURL cueURL: URL) -> [String] {
+        guard cueURL.pathExtension.lowercased() == "cue" else { return [] }
 
-        guard let file = try? FileHandle(forReadingFrom: layout.fileURL) else { return nil }
-        defer { try? file.close() }
-
-        var md5 = Insecure.MD5()
-        let bufferSize = 1024 * 1024
-        var remaining = layout.length
-
-        while true {
-            let toRead = remaining.map { min($0, bufferSize) } ?? bufferSize
-            guard toRead > 0, let data = try? file.read(upToCount: toRead), !data.isEmpty else { break }
-            md5.update(data: data)
-            if let r = remaining {
-                remaining = r - data.count
-                if remaining! <= 0 { break }
+        return parseCUEDataTrackLayouts(cueURL: cueURL).compactMap { layout in
+            guard let file = try? FileHandle(forReadingFrom: layout.fileURL) else { return nil }
+            defer { try? file.close() }
+            if layout.offset > 0 {
+                guard (try? file.seek(toOffset: UInt64(layout.offset))) != nil else { return nil }
             }
-        }
 
-        return md5.finalize().map { String(format: "%02X", $0) }.joined()
+            var md5 = Insecure.MD5()
+            let bufferSize = 1024 * 1024
+            var remaining = layout.length
+
+            while true {
+                let toRead = remaining.map { min($0, bufferSize) } ?? bufferSize
+                guard toRead > 0, let data = try? file.read(upToCount: toRead), !data.isEmpty else { break }
+                md5.update(data: data)
+                if let r = remaining {
+                    remaining = r - data.count
+                    if remaining! <= 0 { break }
+                }
+            }
+
+            return md5.finalize().map { String(format: "%02X", $0) }.joined()
+        }
     }
 
     /// Atari Lynx `.lnx` dumps prepend a 64-byte header ("LYNX" magic); the no-intro DAT

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -90,12 +90,14 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         OESystemIdentifierPCECD:     "NEC - PC Engine CD - TurboGrafx-CD",
         OESystemIdentifierSaturn:    "Sega - Saturn",
         OESystemIdentifierVB:        "Nintendo - Virtual Boy",
+        OESystemIdentifierWS:        "Bandai - WonderSwan",
     ]
 
     // Systems where a single system ID maps to multiple Libretro DAT/CHT directories
     private let systemFallbacks: [String: [String]] = [
         OESystemIdentifierGB: ["Nintendo - Game Boy", "Nintendo - Game Boy Color"],
         OESystemIdentifierNGP: ["SNK - Neo Geo Pocket", "SNK - Neo Geo Pocket Color"],
+        OESystemIdentifierWS: ["Bandai - WonderSwan", "Bandai - WonderSwan Color"],
     ]
 
     // In-memory cache: systemIdentifier → [key → (gameName, libretroSystem)]

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -65,7 +65,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
     private static let chtBaseURL = "https://raw.githubusercontent.com/libretro/libretro-database/master/cht/"
 
     // Disc-based systems use redump DATs instead of no-intro
-    private static let redumpSystems: Set<String> = [OESystemIdentifierPSX, OESystemIdentifierSegaCD, OESystemIdentifierPCECD, OESystemIdentifierSaturn]
+    private static let redumpSystems: Set<String> = [OESystemIdentifierPSX, OESystemIdentifierSegaCD, OESystemIdentifierPCECD, OESystemIdentifierSaturn, OESystemIdentifierPCFX]
 
     // OpenEmu system ID → Libretro directory/DAT name
     private let systemMap: [String: String] = [
@@ -91,6 +91,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         OESystemIdentifierSaturn:    "Sega - Saturn",
         OESystemIdentifierVB:        "Nintendo - Virtual Boy",
         OESystemIdentifierWS:        "Bandai - WonderSwan",
+        OESystemIdentifierPCFX:      "NEC - PC-FX",
     ]
 
     // Systems where a single system ID maps to multiple Libretro DAT/CHT directories

--- a/OpenEmu/LibretroCheatProvider.swift
+++ b/OpenEmu/LibretroCheatProvider.swift
@@ -45,7 +45,9 @@ private struct LibretroCachedCheat: Codable {
     let name: String
     let code: String
     /// Unmodified text as published upstream, kept for feedback correlation. Never shown to the user.
-    let rawCode: String
+    /// Optional only so cache files written before this field existed still decode; falls back to
+    /// `code` wherever a mandatory rawCode is required.
+    let rawCode: String?
 }
 
 final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
@@ -115,7 +117,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
                     anyUpdated = true
                 } else if !anyUpdated {
                     // Nothing updated yet — return the full cached set as-is
-                    return cached.cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode) }
+                    return cached.cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode ?? $0.code) }
                 } else {
                     // Some sources updated, this one didn't — keep cached cheats and this source's existing ETag
                     allCheats.append(contentsOf: cached.cheats)
@@ -126,7 +128,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
             if anyUpdated {
                 saveCachedCheats(LibretroCachedCheatFile(sources: updatedSources, cheats: cheats), md5: md5, systemIdentifier: systemIdentifier)
             }
-            return cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode) }
+            return cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode ?? $0.code) }
         }
 
         // 2. No local cache — resolve game name via DAT (try MD5 first, then serial)
@@ -202,7 +204,7 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
 
         let cheats = dedup(allCheats)
         saveCachedCheats(LibretroCachedCheatFile(sources: sources, cheats: cheats), md5: md5, systemIdentifier: systemIdentifier)
-        return cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode) }
+        return cheats.map { DatabaseCheat(name: Self.decodingHTMLEntities($0.name), code: $0.code, providerName: name, rawCode: $0.rawCode ?? $0.code) }
     }
 
     // MARK: - Local Cache
@@ -253,6 +255,29 @@ final class LibretroCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
               let cached = try? JSONDecoder().decode(LibretroCachedCheatFile.self, from: data)
         else { return nil }
         return cached
+    }
+
+    /// Synchronous lookup for feedback-file migration \u2014 reads the local cache only, no network fetch.
+    /// Returns nil if this game has no cache yet (nothing to reconcile against).
+    func migrationLookup(forMD5 md5: String, systemIdentifier: String) -> (gameName: String?, cheats: [(code: String, rawCode: String)])? {
+        guard let cached = loadCachedCheats(md5: md5, systemIdentifier: systemIdentifier) else { return nil }
+        let gameName = cached.sources.first.map { Self.gameName(fromCHTFileName: $0.chtFileName) }
+        return (gameName, cached.cheats.map { ($0.code, $0.rawCode ?? $0.code) })
+    }
+
+    /// Strips the ".cht" extension and, if present, a trailing known device-suffix tag
+    /// (e.g. "Alien Trilogy (GameShark).cht" \u2192 "Alien Trilogy") to recover the plain game name.
+    private static func gameName(fromCHTFileName chtFileName: String) -> String {
+        var name = chtFileName
+        if name.hasSuffix(".cht") { name.removeLast(4) }
+        for suffix in chtSuffixes {
+            let tag = " (\(suffix))"
+            if name.hasSuffix(tag) {
+                name.removeLast(tag.count)
+                break
+            }
+        }
+        return name
     }
 
     private func saveCachedCheats(_ file: LibretroCachedCheatFile, md5: String, systemIdentifier: String) {

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1679,12 +1679,12 @@ final class OEGameDocument: NSDocument {
 
     /// `cheatSource` (the provider name) is what marks this as Browse Online Cheats-imported,
     /// distinguishing it from cheats added manually or via Cheat Search.
-    func addImportedCheat(code: String, name: String, providerName: String) {
+    func addImportedCheat(code: String, name: String, providerName: String, rawCode: String? = nil) {
         // BSNES is the only core that reads the cheat type — it strips ':' from raw
         // address:value codes only when tagged Raw/Action Replay. Everyone else ignores
         // the type or strips the colon itself, so the code shape is all we need.
         let type = code.contains(":") ? OECheatTypeRaw : OECheatTypeGameShark
-        let cheat = Cheat(code: code, type: type, name: name, cheatSource: providerName)
+        let cheat = Cheat(code: code, type: type, name: name, cheatSource: providerName, rawCode: rawCode)
         cheat.isEnabled = true
         setCheat(cheat)
         cheats.append(cheat)
@@ -2243,7 +2243,8 @@ final class OEGameDocument: NSDocument {
                                              md5: md5,
                                              systemIdentifier: systemPlugin.systemIdentifier,
                                              coreIdentifier: corePlugin.bundleIdentifier,
-                                             coreVersion: corePlugin.version)
+                                             coreVersion: corePlugin.version,
+                                             rawCode: cheat.rawCode)
     }
 
     func setCheat(_ cheat: Cheat) {

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1900,6 +1900,18 @@ final class OEGameDocument: NSDocument {
                     return parts.allSatisfy { CheatCodeValidator.isPCECode(String($0)) }
                 }
             )
+        case OESystemIdentifierSaturn:
+            return CheatFormat(
+                placeholder: NSLocalizedString("12 hex chars per code, e.g. 16073358 0003. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, Saturn"),
+                validationHint: NSLocalizedString("Saturn Action Replay codes must be 12 hex characters (8-char address + 4-char value), e.g. 16073358 0003. The first hex digit must be 1 (word write) or 3 (byte write).", comment: "Add Cheat validation hint, Saturn"),
+                validator: { code in
+                    let parts = code.replacingOccurrences(of: " ", with: "")
+                                    .replacingOccurrences(of: "\n", with: "")
+                                    .split(separator: "+")
+                    guard !parts.isEmpty else { return false }
+                    return parts.allSatisfy { CheatCodeValidator.isSaturnActionReplayCode(String($0)) }
+                }
+            )
         default:
             return defaultCheatFormat
         }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1888,6 +1888,18 @@ final class OEGameDocument: NSDocument {
                     }
                 }
             )
+        case OESystemIdentifierPCE:
+            return CheatFormat(
+                placeholder: NSLocalizedString("Physical (F82DBA:02) or linear (1F0083:02) address. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, PC Engine"),
+                validationHint: NSLocalizedString("PC Engine codes must be a 6 hex digit address plus a 2 hex digit value, e.g. F82DBA:02 or 1F0083:02.", comment: "Add Cheat validation hint, PC Engine"),
+                validator: { code in
+                    let parts = code.replacingOccurrences(of: " ", with: "")
+                                    .replacingOccurrences(of: "\n", with: "")
+                                    .split(separator: "+")
+                    guard !parts.isEmpty else { return false }
+                    return parts.allSatisfy { CheatCodeValidator.isPCECode(String($0)) }
+                }
+            )
         default:
             return defaultCheatFormat
         }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1912,6 +1912,18 @@ final class OEGameDocument: NSDocument {
                     return parts.allSatisfy { CheatCodeValidator.isSaturnActionReplayCode(String($0)) }
                 }
             )
+        case OESystemIdentifierVB:
+            return CheatFormat(
+                placeholder: NSLocalizedString("8 hex digit address + 2 hex digit value, e.g. 05001234:FF. Join multi-line cheats with '+'.", comment: "Add Cheat dialog placeholder, Virtual Boy"),
+                validationHint: NSLocalizedString("Virtual Boy codes must be an 8 hex digit address plus a 2 hex digit value, e.g. 05001234:FF. Only raw WRAM writes are supported (address 0500xxxx-0501xxxx); no Game Genie/GameShark format exists for this system.", comment: "Add Cheat validation hint, Virtual Boy"),
+                validator: { code in
+                    let parts = code.replacingOccurrences(of: " ", with: "")
+                                    .replacingOccurrences(of: "\n", with: "")
+                                    .split(separator: "+")
+                    guard !parts.isEmpty else { return false }
+                    return parts.allSatisfy { CheatCodeValidator.isRawAddressValue(String($0), addressHexChars: 8, valueHexChars: 2) }
+                }
+            )
         default:
             return defaultCheatFormat
         }

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1704,7 +1704,7 @@ final class OEGameDocument: NSDocument {
         }
         cheats.remove(at: index)
         saveUserCheats()
-        promptCheatRemovalFeedback(code: cheat.code)
+        promptCheatRemovalFeedback(cheat)
     }
     
     /// In order to load cheats, we need the core plugin and the ROM to be set.
@@ -2181,13 +2181,13 @@ final class OEGameDocument: NSDocument {
         // Only imported cheats have known-good/bad feedback worth asking about — manual/Cheat Search
         // codes aren't sourced from a shared database, so there's nothing to report back against.
         if cheat.cheatSource != nil {
-            promptCheatRemovalFeedback(code: cheat.code)
+            promptCheatRemovalFeedback(cheat)
         }
     }
 
     /// Shared by every place a cheat gets removed — the menu's Remove item and Browse Online
     /// Cheats' Remove button — so the "did it work" report is asked consistently either way.
-    func promptCheatRemovalFeedback(code: String) {
+    func promptCheatRemovalFeedback(_ cheat: Cheat) {
         guard let md5 = rom.md5Hash else { return }
 
         let existingStatuses = CheatFeedbackService.shared.statuses(forMD5: md5,
@@ -2195,7 +2195,7 @@ final class OEGameDocument: NSDocument {
                                                                     coreIdentifier: corePlugin.bundleIdentifier,
                                                                     coreVersion: corePlugin.version)
         // Already reported on for this core build — don't ask again for a value the user already gave.
-        guard existingStatuses[CheatFeedbackService.key(for: code)] == nil else { return }
+        guard existingStatuses[CheatFeedbackService.key(for: cheat.code)] == nil else { return }
 
         let alert = OEAlert()
         alert.messageText = NSLocalizedString("Cheat Removed", comment: "Cheat removal feedback dialog title")
@@ -2214,11 +2214,16 @@ final class OEGameDocument: NSDocument {
         }
 
         CheatFeedbackService.shared.setStatus(status,
-                                             forCode: code,
+                                             forCode: cheat.code,
                                              md5: md5,
                                              systemIdentifier: systemPlugin.systemIdentifier,
                                              coreIdentifier: corePlugin.bundleIdentifier,
-                                             coreVersion: corePlugin.version)
+                                             coreVersion: corePlugin.version,
+                                             rawCode: cheat.rawCode,
+                                             provider: cheat.cheatSource,
+                                             gameName: rom.game?.displayName,
+                                             serial: rom.serial,
+                                             raHash: retroAchievementsSessionInfo?[OERetroAchievementsGameHashKey] as? String)
     }
 
     /// expects `sender.representedObject` to be a `Cheat` object
@@ -2244,7 +2249,11 @@ final class OEGameDocument: NSDocument {
                                              systemIdentifier: systemPlugin.systemIdentifier,
                                              coreIdentifier: corePlugin.bundleIdentifier,
                                              coreVersion: corePlugin.version,
-                                             rawCode: cheat.rawCode)
+                                             rawCode: cheat.rawCode,
+                                             provider: cheat.cheatSource,
+                                             gameName: rom.game?.displayName,
+                                             serial: rom.serial,
+                                             raHash: retroAchievementsSessionInfo?[OERetroAchievementsGameHashKey] as? String)
     }
 
     func setCheat(_ cheat: Cheat) {

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		6DAB96D7C11047B4AA72206A /* Controller-Mappings.plist in Resources */ = {isa = PBXBuildFile; fileRef = 68416A57049F48B997026285 /* Controller-Mappings.plist */; };
 		8227756B1489471A00B19E27 /* OEGGSystemResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8227755C1489471A00B19E27 /* OEGGSystemResponder.m */; };
 		82C2909114840024007C0214 /* OENGPSystemResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = 820EB7571483F9D3008EC398 /* OENGPSystemResponder.m */; };
+		A1B2C3D4E5F6A7B8C9D0E1F3 /* OENGPSystemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F2 /* OENGPSystemController.swift */; };
 		82DD29DB12369F1100B58A8F /* KeyboardUsages.plist in Resources */ = {isa = PBXBuildFile; fileRef = 82DD29DA12369F1100B58A8F /* KeyboardUsages.plist */; };
 		82DE4B62102655D5007184EB /* XADMaster.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82DE4AEF1026533E007184EB /* XADMaster.framework */; };
 		82DE4B63102655DA007184EB /* UniversalDetector.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82DE4AEE1026533E007184EB /* UniversalDetector.framework */; };
@@ -1350,6 +1351,7 @@
 		820EB7561483F9D3008EC398 /* OENGPSystemResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OENGPSystemResponder.h; sourceTree = "<group>"; };
 		820EB7571483F9D3008EC398 /* OENGPSystemResponder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OENGPSystemResponder.m; sourceTree = "<group>"; };
 		820EB7581483F9D3008EC398 /* OENGPSystemResponderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OENGPSystemResponderClient.h; sourceTree = "<group>"; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* OENGPSystemController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OENGPSystemController.swift; sourceTree = "<group>"; };
 		820EB7591483F9D3008EC398 /* NeoGeoPocket-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "NeoGeoPocket-Info.plist"; sourceTree = "<group>"; };
 		8227754F148946DF00B19E27 /* GameGear.oesystemplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GameGear.oesystemplugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		8227755B1489471A00B19E27 /* OEGGSystemResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEGGSystemResponder.h; sourceTree = "<group>"; };
@@ -3066,6 +3068,7 @@
 		820EB74D1483F9D3008EC398 /* NeoGeoPocket */ = {
 			isa = PBXGroup;
 			children = (
+				A1B2C3D4E5F6A7B8C9D0E1F2 /* OENGPSystemController.swift */,
 				820EB7561483F9D3008EC398 /* OENGPSystemResponder.h */,
 				820EB7571483F9D3008EC398 /* OENGPSystemResponder.m */,
 				820EB7581483F9D3008EC398 /* OENGPSystemResponderClient.h */,
@@ -6182,6 +6185,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				82C2909114840024007C0214 /* OENGPSystemResponder.m in Sources */,
+				A1B2C3D4E5F6A7B8C9D0E1F3 /* OENGPSystemController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenEmu/OpenEmuCheatProvider.swift
+++ b/OpenEmu/OpenEmuCheatProvider.swift
@@ -43,10 +43,19 @@ final class OpenEmuCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         return database[systemIdentifier]?[md5.lowercased()] ?? []
     }
 
+    /// Synchronous lookup for feedback-file migration — the bundled database needs no network fetch.
+    func migrationLookup(forMD5 md5: String, systemIdentifier: String) -> (gameName: String?, cheats: [DatabaseCheat])? {
+        loadIfNeeded()
+        guard let cheats = database[systemIdentifier]?[md5.lowercased()], !cheats.isEmpty else { return nil }
+        return (gameNames[systemIdentifier]?[md5.lowercased()], cheats)
+    }
+
     // MARK: - XML Parsing
 
     // systemIdentifier → [lowercased MD5 → [DatabaseCheat]]
     private var database: [String: [String: [DatabaseCheat]]] = [:]
+    // systemIdentifier → [lowercased MD5 → game title], for feedback-file migration only.
+    private var gameNames: [String: [String: String]] = [:]
     private var loaded = false
     // supportsSystem (main thread) and cheats (off-actor) both trigger the lazy load; serialize it.
     private let loadLock = NSLock()
@@ -69,6 +78,7 @@ final class OpenEmuCheatProvider: CheatDatabaseProvider, @unchecked Sendable {
         parser.delegate = delegate
         parser.parse()
         database = delegate.result
+        gameNames = delegate.gameNames
         // let totalCheats = database.values.flatMap(\.values).flatMap({ $0 }).count
         // log.info("Loaded bundled cheat database: \(totalCheats) cheats")
     }
@@ -78,10 +88,13 @@ private class CheatXMLParserDelegate: NSObject, XMLParserDelegate {
     let providerName: String
     // systemIdentifier → [lowercased MD5 → [DatabaseCheat]]
     var result: [String: [String: [DatabaseCheat]]] = [:]
+    // systemIdentifier → [lowercased MD5 → game title]
+    var gameNames: [String: [String: String]] = [:]
 
     private var currentSystem: String?
     private var currentMD5s: [String] = []
     private var currentCheats: [DatabaseCheat] = []
+    private var currentGameName: String?
 
     init(providerName: String) {
         self.providerName = providerName
@@ -94,6 +107,7 @@ private class CheatXMLParserDelegate: NSObject, XMLParserDelegate {
         case "game":
             currentMD5s = []
             currentCheats = []
+            currentGameName = attributeDict["title"]
         case "hash":
             if let md5 = attributeDict["md5"] {
                 currentMD5s.append(md5.lowercased())
@@ -112,6 +126,9 @@ private class CheatXMLParserDelegate: NSObject, XMLParserDelegate {
         guard elementName == "game", let system = currentSystem, !currentCheats.isEmpty else { return }
         for md5 in currentMD5s {
             result[system, default: [:]][md5] = currentCheats
+            if let currentGameName {
+                gameNames[system, default: [:]][md5] = currentGameName
+            }
         }
     }
 }

--- a/OpenEmu/OpenEmuCheatProvider.swift
+++ b/OpenEmu/OpenEmuCheatProvider.swift
@@ -100,7 +100,8 @@ private class CheatXMLParserDelegate: NSObject, XMLParserDelegate {
             }
         case "cheat":
             if let code = attributeDict["code"], let desc = attributeDict["description"], !code.isEmpty {
-                currentCheats.append(DatabaseCheat(name: desc, code: code, providerName: providerName))
+                // This provider does no normalization, so the stored code is already the raw source text.
+                currentCheats.append(DatabaseCheat(name: desc, code: code, providerName: providerName, rawCode: code))
             }
         default:
             break

--- a/OpenEmu/SystemPlugins/NeoGeoPocket/NeoGeoPocket-Info.plist
+++ b/OpenEmu/SystemPlugins/NeoGeoPocket/NeoGeoPocket-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSPrincipalClass</key>
-	<string>OESystemController</string>
+	<string>$(PRODUCT_NAME:c99extidentifier).OENGPSystemController</string>
 	<key>OEControlListKey</key>
 	<array>
 		<array>

--- a/OpenEmu/SystemPlugins/NeoGeoPocket/OENGPSystemController.swift
+++ b/OpenEmu/SystemPlugins/NeoGeoPocket/OENGPSystemController.swift
@@ -1,4 +1,5 @@
 // Copyright (c) 2026, OpenEmu Team
+// Author: Leonardo Kasperavičius
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:

--- a/OpenEmu/SystemPlugins/NeoGeoPocket/OENGPSystemController.swift
+++ b/OpenEmu/SystemPlugins/NeoGeoPocket/OENGPSystemController.swift
@@ -1,0 +1,38 @@
+// Copyright (c) 2026, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import OpenEmuSystem
+
+class OENGPSystemController: OESystemController {
+    // Catalog number at header offset 0x20 (little-endian uint16). Part of the
+    // cartridge's actual game code, so it stays constant across differing ROM
+    // dumps and matches the no-intro DAT's "serial" field (as a 4-digit hex string).
+    override func serialLookup(for file: OEFile) -> String? {
+        let data = file.readData(in: NSRange(location: 0x20, length: 2))
+        guard data.count == 2 else { return nil }
+        let catalog = UInt16(data[0]) | (UInt16(data[1]) << 8)
+        return String(format: "%04X", catalog)
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR integrates more systems with the [Libretro Cheat Database](https://github.com/libretro/libretro-database), as initially done in https://github.com/OpenEmu-Silicon/OpenEmu-Silicon/pull/715

The goal was to catch up with all the cheat code/search functionality implemented in https://github.com/OpenEmu-Silicon/OpenEmu-Silicon/issues/677, before moving forward with https://github.com/OpenEmu-Silicon/OpenEmu-Silicon/issues/680

**Supported New Systems**

| System | Core |
|--------|------|
| Atari Lynx | Mednafen |
| Neo Geo Pocket | Mednafen |
| PC Engine / TurboGrafx-16 | Mednafen |
| PC Engine CD / TurboGrafx-CD | Mednafen |
| PC-FX | Mednafen |
| Sega Saturn | Mednafen |
| Virtual Boy | Mednafen |
| WonderSwan | Mednafen |

**Important:** Arcade/MAME cheats were not integrated yet. I am evaluating the possibility of getting approval from [Pugsy's Cheats](https://www.mamecheat.co.uk/) to use their compilation as another online database provider.

There were also some adjustments and improvements, mainly:
- Better update handling of Libretro's cached database
- New information added to the cheat feedbacks, in order to support the [CheatWorks](https://docs.google.com/document/d/1aSCE8eM-5vdiFeT385akEW2ge4NhxRERF7mRW4elG94/edit?tab=t.0#heading=h.bwa8hbe44smr) server in the future

## What did you test?

It was a lot of manual testing to guarantee that cheats were working against the formats provided in Libretro.

For each platform, basically what I did was:
- Evaluate all cheat code formats provided in Libretro's CHT files (if existent)
- Test them inside 1-2 games, via manual Add Cheat function
- Add integration and check if the games were found in the DAT/RDB catalogue files
- Check if the CHT files could be found, and fix Libretro if needed
- Waited for Libretro team to merge the changes for each platform (if needed) and retested

Here's a list of PR's with the fixes and new cheats on Libretro's repository:

- [x] Atary Lynx PR: https://github.com/libretro/libretro-database/pull/1721
- [x] Neo Geo Pocket / Color: https://github.com/libretro/libretro-database/pull/1722
- [x] PC Engine / CD: https://github.com/libretro/libretro-database/pull/1723
- [x] Virtual Boy: https://github.com/libretro/libretro-database/pull/1724
- [x] Sega Saturn: https://github.com/libretro/libretro-database/pull/1725
- [x] WonderSwan / Color: https://github.com/libretro/libretro-database/pull/1726
- [x] PC-FX: https://github.com/libretro/libretro-database/pull/1727

## Which cores or systems are affected?

- **Mednafen**: required changes to retrieve more game information, and the ability to write ROM-patches for WonderSwan

## Did you use AI tools?

Code assistance, adversarial-reviewer agent, task automation

## Linked issues

Related to #680  

---

## How to test locally

-

---

## PR checklist

- [x] Branched from an up-to-date `main` (ran `git fetch origin && git merge origin/main`)
- [x] Build passes: `./Scripts/verify.sh` (or `xcodebuild -workspace OpenEmu-metal.xcworkspace -scheme OpenEmu -configuration Debug -destination 'platform=macOS,arch=arm64' build`)
- [x] Tested on Apple Silicon (M1 / M2 / M3 / M4 Mac)
- [x] No build logs, binaries, or credentials committed
- [x] Copyright headers preserved on all modified files
- [x] New files (if any) include the BSD 2-Clause license header
